### PR TITLE
feat(m2-lane00): M2 shared contract schemas

### DIFF
--- a/packages/shared/src/contracts/index.ts
+++ b/packages/shared/src/contracts/index.ts
@@ -167,3 +167,97 @@ export const RunRecordSchema = z.object({
 });
 
 export type RunRecord = z.infer<typeof RunRecordSchema>;
+
+// ── M2 schemas ────────────────────────────────────────────────────────────────
+
+export const ExtensionEventEntityTypeSchema = z.enum([
+  "repository",
+  "plan",
+  "milestone",
+  "run",
+  "handoff",
+  "artifact",
+  "worktree"
+]);
+
+export const ExtensionEventKindSchema = z.enum([
+  "created",
+  "updated",
+  "status.changed",
+  "checkpoint.saved",
+  "checkpoint.restored",
+  "handoff.created",
+  "artifact.created",
+  "validation.failed",
+  "error"
+]);
+
+export const ExtensionEventSchema = z.object({
+  version: z.literal(CONTRACT_VERSION),
+  id: z.string().min(1),
+  requestId: z.string().min(1).optional(),
+  runId: z.string().min(1).optional(),
+  entityType: ExtensionEventEntityTypeSchema,
+  entityId: z.string().min(1),
+  kind: ExtensionEventKindSchema,
+  timestamp: z.string().min(1),
+  payload: z.record(z.string(), z.unknown())
+});
+
+export type ExtensionEvent = z.infer<typeof ExtensionEventSchema>;
+
+export const WorktreeLeaseStateSchema = z.enum([
+  "active",
+  "released",
+  "orphaned"
+]);
+
+export const WorktreeLeaseSchema = z.object({
+  version: z.literal(CONTRACT_VERSION),
+  id: z.string().min(1),
+  runId: z.string().min(1),
+  repositoryId: z.string().min(1),
+  branchName: z.string().min(1),
+  worktreePath: z.string().min(1),
+  state: WorktreeLeaseStateSchema,
+  headCommit: z.string().min(1).optional(),
+  createdAt: z.string().min(1),
+  releasedAt: z.string().min(1).optional()
+});
+
+export type WorktreeLease = z.infer<typeof WorktreeLeaseSchema>;
+
+export const MilestoneStatusSchema = z.enum([
+  "pending",
+  "ready",
+  "running",
+  "paused",
+  "completed",
+  "failed",
+  "canceled",
+  "blocked"
+]);
+
+export const MilestoneRecordSchema = z.object({
+  version: z.literal(CONTRACT_VERSION),
+  id: z.string().min(1),
+  planId: z.string().min(1),
+  title: z.string().min(1),
+  order: z.number().int().min(0),
+  status: MilestoneStatusSchema,
+  acceptanceCriteria: z.array(z.string()),
+  nodeIds: z.array(z.string())
+});
+
+export type MilestoneRecord = z.infer<typeof MilestoneRecordSchema>;
+
+export const RunSnapshotSchema = z.object({
+  version: z.literal(CONTRACT_VERSION),
+  runId: z.string().min(1),
+  status: RunStatusSchema,
+  currentMilestoneId: z.string().min(1).nullable(),
+  lastCheckpointId: z.string().min(1).nullable(),
+  snapshotAt: z.string().min(1)
+});
+
+export type RunSnapshot = z.infer<typeof RunSnapshotSchema>;

--- a/packages/shared/test/contracts/m2-schemas.test.ts
+++ b/packages/shared/test/contracts/m2-schemas.test.ts
@@ -1,0 +1,158 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ExtensionEventSchema,
+  MilestoneRecordSchema,
+  RunSnapshotSchema,
+  WorktreeLeaseSchema
+} from "../../src/contracts";
+
+const fixturesDir = path.resolve(
+  __dirname,
+  "../../../../test/fixtures/contracts"
+);
+
+const loadFixture = (relativePath: string): unknown => {
+  const fullPath = path.join(fixturesDir, relativePath);
+  return JSON.parse(readFileSync(fullPath, "utf8")) as unknown;
+};
+
+// ── ExtensionEventSchema ──────────────────────────────────────────────────────
+
+describe("ExtensionEventSchema", () => {
+  it("accepts a minimal valid event fixture", () => {
+    const parsed = ExtensionEventSchema.parse(
+      loadFixture("events/valid/minimal.json")
+    );
+
+    expect(parsed.id).toBe("evt_001");
+    expect(parsed.entityType).toBe("run");
+    expect(parsed.kind).toBe("created");
+  });
+
+  it("rejects an event fixture with missing entityType", () => {
+    const result = ExtensionEventSchema.safeParse(
+      loadFixture("events/invalid/missing-entity-type.json")
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("survives a json round trip", () => {
+    const fixture = loadFixture("events/valid/minimal.json");
+    const parsed = ExtensionEventSchema.parse(fixture);
+    const roundTripped = JSON.parse(JSON.stringify(parsed)) as unknown;
+
+    expect(ExtensionEventSchema.parse(roundTripped)).toEqual(parsed);
+  });
+});
+
+// ── WorktreeLeaseSchema ───────────────────────────────────────────────────────
+
+describe("WorktreeLeaseSchema", () => {
+  it("accepts a valid active lease fixture", () => {
+    const parsed = WorktreeLeaseSchema.parse(
+      loadFixture("worktree-leases/valid/active.json")
+    );
+
+    expect(parsed.id).toBe("lease_001");
+    expect(parsed.state).toBe("active");
+    expect(parsed.runId).toBe("run_001");
+  });
+
+  it("rejects a lease fixture with an invalid state", () => {
+    const result = WorktreeLeaseSchema.safeParse(
+      loadFixture("worktree-leases/invalid/bad-state.json")
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("survives a json round trip", () => {
+    const fixture = loadFixture("worktree-leases/valid/active.json");
+    const parsed = WorktreeLeaseSchema.parse(fixture);
+    const roundTripped = JSON.parse(JSON.stringify(parsed)) as unknown;
+
+    expect(WorktreeLeaseSchema.parse(roundTripped)).toEqual(parsed);
+  });
+});
+
+// ── MilestoneRecordSchema ─────────────────────────────────────────────────────
+
+describe("MilestoneRecordSchema", () => {
+  it("accepts a minimal valid milestone fixture", () => {
+    const parsed = MilestoneRecordSchema.parse(
+      loadFixture("milestones/valid/minimal.json")
+    );
+
+    expect(parsed.id).toBe("ms_001");
+    expect(parsed.planId).toBe("plan_001");
+    expect(parsed.status).toBe("pending");
+    expect(parsed.order).toBe(0);
+  });
+
+  it("rejects a milestone fixture without a planId", () => {
+    const result = MilestoneRecordSchema.safeParse(
+      loadFixture("milestones/invalid/missing-plan-id.json")
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("survives a json round trip", () => {
+    const fixture = loadFixture("milestones/valid/minimal.json");
+    const parsed = MilestoneRecordSchema.parse(fixture);
+    const roundTripped = JSON.parse(JSON.stringify(parsed)) as unknown;
+
+    expect(MilestoneRecordSchema.parse(roundTripped)).toEqual(parsed);
+  });
+});
+
+// ── RunSnapshotSchema ─────────────────────────────────────────────────────────
+
+describe("RunSnapshotSchema", () => {
+  it("accepts a minimal valid snapshot fixture with null milestone and checkpoint", () => {
+    const parsed = RunSnapshotSchema.parse(
+      loadFixture("run-snapshots/valid/minimal.json")
+    );
+
+    expect(parsed.runId).toBe("run_001");
+    expect(parsed.status).toBe("running");
+    expect(parsed.currentMilestoneId).toBeNull();
+    expect(parsed.lastCheckpointId).toBeNull();
+  });
+
+  it("rejects a snapshot fixture without a runId", () => {
+    const result = RunSnapshotSchema.safeParse(
+      loadFixture("run-snapshots/invalid/missing-run-id.json")
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("survives a json round trip", () => {
+    const fixture = loadFixture("run-snapshots/valid/minimal.json");
+    const parsed = RunSnapshotSchema.parse(fixture);
+    const roundTripped = JSON.parse(JSON.stringify(parsed)) as unknown;
+
+    expect(RunSnapshotSchema.parse(roundTripped)).toEqual(parsed);
+  });
+
+  it("accepts a snapshot with non-null milestone and checkpoint ids", () => {
+    const snapshot = {
+      version: 1,
+      runId: "run_002",
+      status: "running",
+      currentMilestoneId: "ms_001",
+      lastCheckpointId: "chk_001",
+      snapshotAt: "2026-03-16T01:00:00Z"
+    };
+
+    const parsed = RunSnapshotSchema.parse(snapshot);
+    expect(parsed.currentMilestoneId).toBe("ms_001");
+    expect(parsed.lastCheckpointId).toBe("chk_001");
+  });
+});

--- a/test/fixtures/contracts/events/invalid/missing-entity-type.json
+++ b/test/fixtures/contracts/events/invalid/missing-entity-type.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "id": "evt_002",
+  "entityId": "run_001",
+  "kind": "created",
+  "timestamp": "2026-03-16T00:00:00Z",
+  "payload": {}
+}

--- a/test/fixtures/contracts/events/valid/minimal.json
+++ b/test/fixtures/contracts/events/valid/minimal.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "id": "evt_001",
+  "runId": "run_001",
+  "entityType": "run",
+  "entityId": "run_001",
+  "kind": "created",
+  "timestamp": "2026-03-16T00:00:00Z",
+  "payload": {}
+}

--- a/test/fixtures/contracts/milestones/invalid/missing-plan-id.json
+++ b/test/fixtures/contracts/milestones/invalid/missing-plan-id.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "id": "ms_002",
+  "title": "Set up scaffold",
+  "order": 0,
+  "status": "pending",
+  "acceptanceCriteria": [],
+  "nodeIds": []
+}

--- a/test/fixtures/contracts/milestones/valid/minimal.json
+++ b/test/fixtures/contracts/milestones/valid/minimal.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "id": "ms_001",
+  "planId": "plan_001",
+  "title": "Set up scaffold",
+  "order": 0,
+  "status": "pending",
+  "acceptanceCriteria": [],
+  "nodeIds": []
+}

--- a/test/fixtures/contracts/run-snapshots/invalid/missing-run-id.json
+++ b/test/fixtures/contracts/run-snapshots/invalid/missing-run-id.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "status": "running",
+  "currentMilestoneId": null,
+  "lastCheckpointId": null,
+  "snapshotAt": "2026-03-16T00:00:00Z"
+}

--- a/test/fixtures/contracts/run-snapshots/valid/minimal.json
+++ b/test/fixtures/contracts/run-snapshots/valid/minimal.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "runId": "run_001",
+  "status": "running",
+  "currentMilestoneId": null,
+  "lastCheckpointId": null,
+  "snapshotAt": "2026-03-16T00:00:00Z"
+}

--- a/test/fixtures/contracts/worktree-leases/invalid/bad-state.json
+++ b/test/fixtures/contracts/worktree-leases/invalid/bad-state.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "id": "lease_002",
+  "runId": "run_001",
+  "repositoryId": "repo_001",
+  "branchName": "attractor/ses001/repo001/a1",
+  "worktreePath": "/tmp/worktrees/repo_001",
+  "state": "unknown-state",
+  "createdAt": "2026-03-16T00:00:00Z"
+}

--- a/test/fixtures/contracts/worktree-leases/valid/active.json
+++ b/test/fixtures/contracts/worktree-leases/valid/active.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "id": "lease_001",
+  "runId": "run_001",
+  "repositoryId": "repo_001",
+  "branchName": "attractor/ses001/repo001/a1",
+  "worktreePath": "/tmp/worktrees/repo_001",
+  "state": "active",
+  "createdAt": "2026-03-16T00:00:00Z"
+}


### PR DESCRIPTION
## Summary

- Adds four new Zod schemas to `packages/shared/src/contracts/index.ts`: `ExtensionEventSchema`, `WorktreeLeaseSchema`, `MilestoneRecordSchema`, `RunSnapshotSchema`
- Each schema has inferred TypeScript type exports alongside it
- 13 new unit tests (valid fixture, invalid fixture, round-trip parse per schema + extra snapshot test)
- New test fixtures under `test/fixtures/contracts/{events,worktree-leases,milestones,run-snapshots}/`

## Acceptance Criteria Met

- ✅ All four new schemas exported from the existing contracts entrypoint
- ✅ Each schema has ≥1 valid fixture test and ≥1 invalid fixture test
- ✅ `RunSnapshotSchema` models current run status + current milestone + last checkpoint
- ✅ No extension behavior added — only shared contract definitions
- ✅ 85/85 tests pass; typecheck and lint clean

## Unblocks

Wave 2: Lane 20 (event log) and Lane 30 (worktree manager) both depend on this lane.