### PR TITLE
feat(m2/lane-20): FileEventLog — JSONL event log with schema validation

### DIFF
--- a/packages/extension/src/storage/events/file-event-log.ts
+++ b/packages/extension/src/storage/events/file-event-log.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { ExtensionEventSchema, type ExtensionEvent } from "@attractor/shared";
+
+import { type EventLog } from "./index";
+
+/**
+ * File-backed EventLog implementation.
+ *
+ * Events are persisted as newline-delimited JSON (JSONL) at:
+ *   <storageRoot>/runs/<runId>/events.jsonl
+ *
+ * Each call to `append` writes exactly one JSON line and flushes.
+ * Each call to `listByRun` parses and validates every line; a malformed
+ * or schema-invalid line causes an explicit Error rather than silent skipping.
+ */
+export class FileEventLog implements EventLog {
+  constructor(private readonly storageRoot: string) {}
+
+  private logPath(runId: string): string {
+    return path.join(this.storageRoot, "runs", runId, "events.jsonl");
+  }
+
+  async append(event: ExtensionEvent): Promise<void> {
+    if (!event.runId) {
+      throw new Error(
+        `EventLog.append: event "${event.id}" has no runId — cannot determine log path`
+      );
+    }
+    const filePath = this.logPath(event.runId);
+    const dir = path.dirname(filePath);
+    await fs.promises.mkdir(dir, { recursive: true });
+    const line = JSON.stringify(event) + "\n";
+    await fs.promises.appendFile(filePath, line, "utf-8");
+  }
+
+  async listByRun(runId: string): Promise<ExtensionEvent[]> {
+    const filePath = this.logPath(runId);
+    let content: string;
+    try {
+      content = await fs.promises.readFile(filePath, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return [];
+      }
+      throw err;
+    }
+
+    const lines = content.split("\n").filter((l) => l.trim() !== "");
+    const events: ExtensionEvent[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line === undefined) continue;
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        throw new Error(
+          `EventLog[${runId}] line ${i + 1}: invalid JSON — ${line.slice(0, 80)}`
+        );
+      }
+
+      const result = ExtensionEventSchema.safeParse(parsed);
+      if (!result.success) {
+        throw new Error(
+          `EventLog[${runId}] line ${i + 1}: schema validation failed — ${result.error.message}`
+        );
+      }
+
+      events.push(result.data);
+    }
+
+    return events;
+  }
+}

--- a/packages/extension/src/storage/events/index.ts
+++ b/packages/extension/src/storage/events/index.ts
@@ -1,0 +1,20 @@
+import { type ExtensionEvent } from "@attractor/shared";
+
+/**
+ * EventLog provides append-only storage for extension events scoped to a run.
+ * Events are persisted in JSONL format at storage/runs/<run-id>/events.jsonl.
+ */
+export interface EventLog {
+  /**
+   * Append a single event to the log for its run.
+   * Creates the parent directory and file if they do not exist.
+   */
+  append(event: ExtensionEvent): Promise<void>;
+
+  /**
+   * Return all events for a given run in append order.
+   * Returns an empty array if no log exists for the run yet.
+   * Throws if any line fails schema validation.
+   */
+  listByRun(runId: string): Promise<ExtensionEvent[]>;
+}

--- a/packages/extension/test/storage/events/file-event-log.test.ts
+++ b/packages/extension/test/storage/events/file-event-log.test.ts
@@ -1,0 +1,150 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { FileEventLog } from "../../../src/storage/events/file-event-log";
+
+function makeEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    version: 1 as const,
+    id: "evt_001",
+    runId: "run_abc",
+    entityType: "run" as const,
+    entityId: "run_abc",
+    kind: "status.changed" as const,
+    timestamp: "2026-03-17T00:00:00.000Z",
+    payload: {},
+    ...overrides
+  };
+}
+
+describe("FileEventLog", () => {
+  describe("listByRun — empty log", () => {
+    it("returns an empty array when no log file exists", async () => {
+      const root = await mkdtemp(path.join(os.tmpdir(), "attractor-evtlog-"));
+      try {
+        const log = new FileEventLog(root);
+        const events = await log.listByRun("run_nonexistent");
+        expect(events).toEqual([]);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("append", () => {
+    it("creates parent directories and file on first append", async () => {
+      const root = await mkdtemp(path.join(os.tmpdir(), "attractor-evtlog-"));
+      try {
+        const log = new FileEventLog(root);
+        const event = makeEvent();
+        await log.append(event);
+
+        const events = await log.listByRun("run_abc");
+        expect(events).toHaveLength(1);
+        expect(events[0]?.id).toBe("evt_001");
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+
+    it("appends exactly one line per call", async () => {
+      const root = await mkdtemp(path.join(os.tmpdir(), "attractor-evtlog-"));
+      try {
+        const log = new FileEventLog(root);
+        await log.append(makeEvent({ id: "evt_001" }));
+        await log.append(makeEvent({ id: "evt_002" }));
+        await log.append(makeEvent({ id: "evt_003" }));
+
+        const events = await log.listByRun("run_abc");
+        expect(events).toHaveLength(3);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+
+    it("throws when event has no runId", async () => {
+      const root = await mkdtemp(path.join(os.tmpdir(), "attractor-evtlog-"));
+      try {
+        const log = new FileEventLog(root);
+        const event = makeEvent({ runId: undefined });
+        await expect(log.append(event)).rejects.toThrow(/no runId/);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("listByRun — multiple appends in order", () => {
+    it("returns events in append order", async () => {
+      const root = await mkdtemp(path.join(os.tmpdir(), "attractor-evtlog-"));
+      try {
+        const log = new FileEventLog(root);
+        const ids = ["evt_a", "evt_b", "evt_c", "evt_d"];
+        for (const id of ids) {
+          await log.append(makeEvent({ id }));
+        }
+
+        const events = await log.listByRun("run_abc");
+        expect(events.map((e) => e.id)).toEqual(ids);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+
+    it("keeps runs isolated from each other", async () => {
+      const root = await mkdtemp(path.join(os.tmpdir(), "attractor-evtlog-"));
+      try {
+        const log = new FileEventLog(root);
+        await log.append(makeEvent({ id: "evt_run1", runId: "run_001" }));
+        await log.append(makeEvent({ id: "evt_run2", runId: "run_002" }));
+
+        const run1Events = await log.listByRun("run_001");
+        const run2Events = await log.listByRun("run_002");
+
+        expect(run1Events.map((e) => e.id)).toEqual(["evt_run1"]);
+        expect(run2Events.map((e) => e.id)).toEqual(["evt_run2"]);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("listByRun — malformed line rejection", () => {
+    it("throws on a line with invalid JSON", async () => {
+      const root = await mkdtemp(path.join(os.tmpdir(), "attractor-evtlog-"));
+      try {
+        const log = new FileEventLog(root);
+        // Append a valid event, then corrupt the file
+        await log.append(makeEvent({ id: "evt_valid" }));
+        const { writeFile } = await import("node:fs/promises");
+        const filePath = `${root}/runs/run_abc/events.jsonl`;
+        await writeFile(filePath, `not-json\n{"id":"evt_valid"}\n`);
+
+        await expect(log.listByRun("run_abc")).rejects.toThrow(/invalid JSON/);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+
+    it("throws on a line that fails schema validation", async () => {
+      const root = await mkdtemp(path.join(os.tmpdir(), "attractor-evtlog-"));
+      try {
+        const log = new FileEventLog(root);
+        await log.append(makeEvent({ id: "evt_valid" }));
+        const { writeFile } = await import("node:fs/promises");
+        const filePath = `${root}/runs/run_abc/events.jsonl`;
+        // Write a line that is valid JSON but fails ExtensionEventSchema
+        await writeFile(filePath, `{"id":"evt_valid"}\n{"broken":true}\n`);
+
+        await expect(log.listByRun("run_abc")).rejects.toThrow(
+          /schema validation failed/
+        );
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `EventLog` interface (`append` / `listByRun`) in `packages/extension/src/storage/events/index.ts`
- Implements `FileEventLog` persisting events as newline-delimited JSON at `<storageRoot>/runs/<runId>/events.jsonl`
- Validates every line via `ExtensionEventSchema` on read; throws descriptive errors on bad JSON or schema violations
- Does **not** wire into `createStorageServices()` — that is Lane 40's responsibility

## Test coverage

8 new tests (108 total passing):
- empty log returns `[]`
- creates parent dirs and file on first `append`
- exactly one line per call
- throws when `runId` is missing
- events returned in append order
- run isolation (separate JSONL files per runId)
- throws on invalid JSON line
- throws on schema-invalid line

## Quality gates

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` 108/108 ✅

## Lane dependency

Unblocks Lane 40 (snapshot projector + `createStorageServices()` wiring).