### PR TITLE
feat(m2/lane-40): SnapshotProjector — event-log-based run snapshot projection

### DIFF
--- a/packages/extension/src/storage/services.ts
+++ b/packages/extension/src/storage/services.ts
@@ -9,6 +9,10 @@ import {
   type RepositoryRegistry
 } from "./repositories/file-repository-registry";
 import { FileRunRegistry, type RunRegistry } from "./runs/file-run-registry";
+import { FileEventLog } from "./events/file-event-log";
+import { type EventLog } from "./events/index";
+import { EventLogSnapshotProjector } from "./snapshots/snapshot-projector";
+import { type SnapshotProjector } from "./snapshots/index";
 
 export interface ExtensionStorageUriLike {
   fsPath: string;
@@ -23,15 +27,20 @@ export interface StorageServices {
   repositoryRegistry: RepositoryRegistry;
   planRegistry: PlanRegistry;
   runRegistry: RunRegistry;
+  eventLog: EventLog;
+  snapshotProjector: SnapshotProjector;
 }
 
 export const createStorageServices = (
   rootDirectory: string
 ): StorageServices => {
+  const eventLog = new FileEventLog(rootDirectory);
   return {
     repositoryRegistry: new FileRepositoryRegistry(rootDirectory),
     planRegistry: new FilePlanRegistry(rootDirectory),
-    runRegistry: new FileRunRegistry(rootDirectory)
+    runRegistry: new FileRunRegistry(rootDirectory),
+    eventLog,
+    snapshotProjector: new EventLogSnapshotProjector(eventLog)
   };
 };
 

--- a/packages/extension/src/storage/snapshots/index.ts
+++ b/packages/extension/src/storage/snapshots/index.ts
@@ -1,0 +1,16 @@
+import { type RunSnapshot } from "@attractor/shared";
+
+/**
+ * SnapshotProjector derives a read-model RunSnapshot by replaying the ordered
+ * event stream for a run.  All projection is deterministic — given the same
+ * ordered event sequence it always returns the same snapshot.
+ *
+ * M2 scope: no live subscriptions, no caching, no webview push.
+ */
+export interface SnapshotProjector {
+  /**
+   * Read all events for `runId` via the underlying EventLog and project them
+   * into a RunSnapshot.  Returns null when no events have been recorded yet.
+   */
+  project(runId: string): Promise<RunSnapshot | null>;
+}

--- a/packages/extension/src/storage/snapshots/snapshot-projector.ts
+++ b/packages/extension/src/storage/snapshots/snapshot-projector.ts
@@ -1,0 +1,85 @@
+import {
+  RunSnapshotSchema,
+  type ExtensionEvent,
+  type RunSnapshot
+} from "@attractor/shared";
+
+import { type EventLog } from "../events/index";
+import { type SnapshotProjector } from "./index";
+
+/**
+ * Projects a RunSnapshot by replaying an ordered event stream from EventLog.
+ *
+ * Projection rules (M2):
+ *   - Last `status.changed` event sets `status`.
+ *   - Last `milestone`-entity event with entityType === "milestone" sets `currentMilestoneId`.
+ *   - Last `checkpoint.saved` event sets `lastCheckpointId` (entityId of the event).
+ *   - When no events exist, returns null.
+ *
+ * No caching, no live subscriptions — pure deterministic replay.
+ */
+export class EventLogSnapshotProjector implements SnapshotProjector {
+  constructor(private readonly eventLog: EventLog) {}
+
+  async project(runId: string): Promise<RunSnapshot | null> {
+    const events = await this.eventLog.listByRun(runId);
+
+    if (events.length === 0) {
+      return null;
+    }
+
+    let status: RunSnapshot["status"] = "queued";
+    let currentMilestoneId: string | null = null;
+    let lastCheckpointId: string | null = null;
+    let snapshotAt = events[0]!.timestamp;
+
+    for (const event of events) {
+      snapshotAt = event.timestamp;
+
+      if (event.kind === "status.changed") {
+        // Extract the new status from payload if present, else leave unchanged
+        const newStatus = extractStatus(event);
+        if (newStatus !== null) {
+          status = newStatus;
+        }
+      }
+
+      if (event.entityType === "milestone") {
+        currentMilestoneId = event.entityId;
+      }
+
+      if (event.kind === "checkpoint.saved") {
+        lastCheckpointId = event.entityId;
+      }
+    }
+
+    return RunSnapshotSchema.parse({
+      version: 1,
+      runId,
+      status,
+      currentMilestoneId,
+      lastCheckpointId,
+      snapshotAt
+    });
+  }
+}
+
+/**
+ * Safely extract `status` from a `status.changed` event payload.
+ * Returns null if the payload doesn't carry a recognized status string.
+ */
+function extractStatus(event: ExtensionEvent): RunSnapshot["status"] | null {
+  const raw = event.payload["status"];
+  const valid: RunSnapshot["status"][] = [
+    "queued",
+    "running",
+    "paused",
+    "completed",
+    "failed",
+    "canceled"
+  ];
+  if (typeof raw === "string" && (valid as string[]).includes(raw)) {
+    return raw as RunSnapshot["status"];
+  }
+  return null;
+}

--- a/packages/extension/test/smoke/activation.test.ts
+++ b/packages/extension/test/smoke/activation.test.ts
@@ -63,7 +63,9 @@ describe("activateAttractor", () => {
         save: vi.fn(),
         getById: vi.fn(),
         list: vi.fn()
-      }
+      },
+      eventLog: { append: vi.fn(), listByRun: vi.fn() },
+      snapshotProjector: { project: vi.fn() }
     };
 
     const createStorageServices = vi.fn(() => storageServices);
@@ -106,7 +108,9 @@ describe("activateAttractor", () => {
     const storageServices: StorageServicesLike = {
       repositoryRegistry: { save: vi.fn(), getById: vi.fn(), list: vi.fn() },
       planRegistry: { save: vi.fn(), getById: vi.fn(), list: vi.fn() },
-      runRegistry: { save: vi.fn(), getById: vi.fn(), list: vi.fn() }
+      runRegistry: { save: vi.fn(), getById: vi.fn(), list: vi.fn() },
+      eventLog: { append: vi.fn(), listByRun: vi.fn() },
+      snapshotProjector: { project: vi.fn() }
     };
     const createStorageServices = vi.fn(() => storageServices);
 
@@ -135,7 +139,9 @@ describe("activateAttractor", () => {
     const storageServices: StorageServicesLike = {
       repositoryRegistry: { save: vi.fn(), getById: vi.fn(), list: vi.fn() },
       planRegistry: { save: vi.fn(), getById: vi.fn(), list: vi.fn() },
-      runRegistry: { save: vi.fn(), getById: vi.fn(), list: vi.fn() }
+      runRegistry: { save: vi.fn(), getById: vi.fn(), list: vi.fn() },
+      eventLog: { append: vi.fn(), listByRun: vi.fn() },
+      snapshotProjector: { project: vi.fn() }
     };
     const createStorageServices = vi.fn(() => storageServices);
 

--- a/packages/extension/test/storage/snapshots/snapshot-projector.test.ts
+++ b/packages/extension/test/storage/snapshots/snapshot-projector.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+
+import { type ExtensionEvent } from "@attractor/shared";
+
+import { type EventLog } from "../../../src/storage/events/index";
+import { EventLogSnapshotProjector } from "../../../src/storage/snapshots/snapshot-projector";
+
+/** Minimal stub EventLog that returns a fixed event list. */
+function makeEventLog(events: ExtensionEvent[]): EventLog {
+  return {
+    async append() {
+      /* no-op */
+    },
+    async listByRun() {
+      return events;
+    }
+  };
+}
+
+function makeEvent(overrides: Partial<ExtensionEvent> = {}): ExtensionEvent {
+  return {
+    version: 1 as const,
+    id: "evt_001",
+    runId: "run_abc",
+    entityType: "run" as const,
+    entityId: "run_abc",
+    kind: "created" as const,
+    timestamp: "2026-03-17T00:00:00.000Z",
+    payload: {},
+    ...overrides
+  };
+}
+
+describe("EventLogSnapshotProjector", () => {
+  describe("project — no events", () => {
+    it("returns null when no events have been recorded", async () => {
+      const projector = new EventLogSnapshotProjector(makeEventLog([]));
+      const snapshot = await projector.project("run_empty");
+      expect(snapshot).toBeNull();
+    });
+  });
+
+  describe("project — status projection", () => {
+    it("reflects the last status.changed event", async () => {
+      const events: ExtensionEvent[] = [
+        makeEvent({
+          id: "e1",
+          kind: "status.changed",
+          payload: { status: "running" }
+        }),
+        makeEvent({
+          id: "e2",
+          kind: "status.changed",
+          payload: { status: "paused" }
+        })
+      ];
+      const projector = new EventLogSnapshotProjector(makeEventLog(events));
+      const snapshot = await projector.project("run_abc");
+      expect(snapshot?.status).toBe("paused");
+    });
+
+    it("ignores a status.changed event with unrecognized status value", async () => {
+      const events: ExtensionEvent[] = [
+        makeEvent({
+          id: "e1",
+          kind: "status.changed",
+          payload: { status: "running" }
+        }),
+        makeEvent({
+          id: "e2",
+          kind: "status.changed",
+          payload: { status: "not-a-valid-status" }
+        })
+      ];
+      const projector = new EventLogSnapshotProjector(makeEventLog(events));
+      const snapshot = await projector.project("run_abc");
+      // Should keep last valid status, not the unrecognized one
+      expect(snapshot?.status).toBe("running");
+    });
+  });
+
+  describe("project — milestone projection", () => {
+    it("tracks the last milestone entity event", async () => {
+      const events: ExtensionEvent[] = [
+        makeEvent({
+          id: "e1",
+          entityType: "milestone",
+          entityId: "ms_001",
+          kind: "created"
+        }),
+        makeEvent({
+          id: "e2",
+          entityType: "milestone",
+          entityId: "ms_002",
+          kind: "updated"
+        })
+      ];
+      const projector = new EventLogSnapshotProjector(makeEventLog(events));
+      const snapshot = await projector.project("run_abc");
+      expect(snapshot?.currentMilestoneId).toBe("ms_002");
+    });
+
+    it("returns null currentMilestoneId when no milestone events exist", async () => {
+      const events: ExtensionEvent[] = [
+        makeEvent({ id: "e1", kind: "created" })
+      ];
+      const projector = new EventLogSnapshotProjector(makeEventLog(events));
+      const snapshot = await projector.project("run_abc");
+      expect(snapshot?.currentMilestoneId).toBeNull();
+    });
+  });
+
+  describe("project — checkpoint projection", () => {
+    it("tracks the last checkpoint.saved entityId", async () => {
+      const events: ExtensionEvent[] = [
+        makeEvent({
+          id: "e1",
+          kind: "checkpoint.saved",
+          entityId: "cp_001"
+        }),
+        makeEvent({
+          id: "e2",
+          kind: "checkpoint.saved",
+          entityId: "cp_002"
+        })
+      ];
+      const projector = new EventLogSnapshotProjector(makeEventLog(events));
+      const snapshot = await projector.project("run_abc");
+      expect(snapshot?.lastCheckpointId).toBe("cp_002");
+    });
+
+    it("returns null lastCheckpointId when no checkpoint events exist", async () => {
+      const events: ExtensionEvent[] = [
+        makeEvent({ id: "e1", kind: "created" })
+      ];
+      const projector = new EventLogSnapshotProjector(makeEventLog(events));
+      const snapshot = await projector.project("run_abc");
+      expect(snapshot?.lastCheckpointId).toBeNull();
+    });
+  });
+
+  describe("project — schema validity", () => {
+    it("returns a schema-valid RunSnapshot", async () => {
+      const events: ExtensionEvent[] = [
+        makeEvent({
+          id: "e1",
+          kind: "status.changed",
+          payload: { status: "completed" }
+        })
+      ];
+      const projector = new EventLogSnapshotProjector(makeEventLog(events));
+      const snapshot = await projector.project("run_abc");
+      expect(snapshot?.version).toBe(1);
+      expect(snapshot?.runId).toBe("run_abc");
+      expect(typeof snapshot?.snapshotAt).toBe("string");
+    });
+
+    it("is deterministic — same event sequence always produces same snapshot", async () => {
+      const events: ExtensionEvent[] = [
+        makeEvent({
+          id: "e1",
+          kind: "status.changed",
+          payload: { status: "running" }
+        }),
+        makeEvent({
+          id: "e2",
+          entityType: "milestone",
+          entityId: "ms_001",
+          kind: "created"
+        }),
+        makeEvent({
+          id: "e3",
+          kind: "checkpoint.saved",
+          entityId: "cp_001"
+        })
+      ];
+      const projector = new EventLogSnapshotProjector(makeEventLog(events));
+      const snap1 = await projector.project("run_abc");
+      const snap2 = await projector.project("run_abc");
+      expect(snap1).toEqual(snap2);
+    });
+  });
+});

--- a/packages/extension/test/storage/storage-services.test.ts
+++ b/packages/extension/test/storage/storage-services.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it } from "vitest";
 import { FilePlanRegistry } from "../../src/storage/plans";
 import { FileRepositoryRegistry } from "../../src/storage/repositories";
 import { FileRunRegistry } from "../../src/storage/runs";
+import { FileEventLog } from "../../src/storage/events/file-event-log";
+import { EventLogSnapshotProjector } from "../../src/storage/snapshots/snapshot-projector";
 import {
   createStorageServices,
   getStorageRoot,
@@ -12,13 +14,23 @@ import {
 } from "../../src/storage/services";
 
 describe("storage services composition", () => {
-  it("composes repository and plan registries from one root path", () => {
+  it("composes repository, plan, and run registries from one root path", () => {
     const rootDirectory = "C:/tmp/attractor";
     const services = createStorageServices(rootDirectory);
 
     expect(services.repositoryRegistry).toBeInstanceOf(FileRepositoryRegistry);
     expect(services.planRegistry).toBeInstanceOf(FilePlanRegistry);
     expect(services.runRegistry).toBeInstanceOf(FileRunRegistry);
+  });
+
+  it("wires event log and snapshot projector", () => {
+    const rootDirectory = "C:/tmp/attractor";
+    const services = createStorageServices(rootDirectory);
+
+    expect(services.eventLog).toBeInstanceOf(FileEventLog);
+    expect(services.snapshotProjector).toBeInstanceOf(
+      EventLogSnapshotProjector
+    );
   });
 
   it("resolves extension storage roots deterministically", () => {
@@ -31,9 +43,11 @@ describe("storage services composition", () => {
     const services: StorageServices = createStorageServices("C:/tmp/attractor");
 
     expect(Object.keys(services).sort()).toEqual([
+      "eventLog",
       "planRegistry",
       "repositoryRegistry",
-      "runRegistry"
+      "runRegistry",
+      "snapshotProjector"
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `SnapshotProjector` interface (`packages/extension/src/storage/snapshots/index.ts`)
- Implements `EventLogSnapshotProjector` that replays `FileEventLog` events to produce a `RunSnapshot` for a given `runId`
- Wires `eventLog` + `snapshotProjector` into `StorageServices` (`packages/extension/src/storage/services.ts`)
- Adds 9 unit tests for the projector and updates storage-services + activation smoke tests

## Quality Gates

- ✅ `pnpm typecheck` — 0 errors
- ✅ `pnpm lint` — 0 warnings
- ✅ `pnpm test` — 125/125 tests pass

## Lane Scope (from docs/plans/m2-lanes.md)

Lane 40 scope: event-sourced snapshot projector + services wiring. Does NOT add live subscriptions, caching, or webview updates.

## Dependencies

- Depends on Lane 20 (FileEventLog) — merged in PR #8
- Depends on Lane 00 (shared contracts, RunSnapshotSchema) — merged in PR #6