### PR TITLE
feat(m3/l1): storage read surface — listActiveRuns, index re-exports, integration tests

### DIFF
--- a/packages/extension/src/storage/plans/index.ts
+++ b/packages/extension/src/storage/plans/index.ts
@@ -1,1 +1,1 @@
-export * from "./file-plan-registry";
+export { PlanRegistry, FilePlanRegistry } from "./file-plan-registry";

--- a/packages/extension/src/storage/repositories/index.ts
+++ b/packages/extension/src/storage/repositories/index.ts
@@ -1,1 +1,4 @@
-export * from "./file-repository-registry";
+export {
+  RepositoryRegistry,
+  FileRepositoryRegistry
+} from "./file-repository-registry";

--- a/packages/extension/src/storage/runs/file-run-registry.ts
+++ b/packages/extension/src/storage/runs/file-run-registry.ts
@@ -7,6 +7,7 @@ export interface RunRegistry {
   save(record: RunRecord): Promise<RunRecord>;
   getById(id: string): Promise<RunRecord | null>;
   list(): Promise<RunRecord[]>;
+  listActiveRuns(): Promise<RunRecord[]>;
 }
 
 const RUNS_DIRECTORY = path.join("storage", "runs");
@@ -108,6 +109,16 @@ export class FileRunRegistry implements RunRegistry {
 
       throw error;
     }
+  }
+
+  async listActiveRuns(): Promise<RunRecord[]> {
+    const activeStatuses = new Set<RunRecord["status"]>([
+      "queued",
+      "running",
+      "paused"
+    ]);
+    const all = await this.list();
+    return all.filter((r) => activeStatuses.has(r.status));
   }
 
   private getRunsDirectory(): string {

--- a/packages/extension/src/storage/runs/index.ts
+++ b/packages/extension/src/storage/runs/index.ts
@@ -1,1 +1,1 @@
-export * from "./file-run-registry";
+export { RunRegistry, FileRunRegistry } from "./file-run-registry";

--- a/packages/extension/test/storage/storage-read-surface.test.ts
+++ b/packages/extension/test/storage/storage-read-surface.test.ts
@@ -1,0 +1,178 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+
+import { describe, it, expect } from "vitest";
+
+import { FileRepositoryRegistry } from "../../src/storage/repositories/file-repository-registry";
+import { FilePlanRegistry } from "../../src/storage/plans/file-plan-registry";
+import { FileRunRegistry } from "../../src/storage/runs/file-run-registry";
+import type {
+  RepositoryRecord,
+  PlanRecord,
+  RunRecord
+} from "@attractor/shared";
+
+const makeTempDir = async () => {
+  const prefix = path.join(os.tmpdir(), "attractor-test-");
+  return mkdtemp(prefix);
+};
+
+describe("storage read surface - File*Registry list APIs", () => {
+  it("repositoryRegistry.list() returns empty array when no records exist", async () => {
+    const tmp = await makeTempDir();
+    try {
+      const repo = new FileRepositoryRegistry(tmp);
+      const list = await repo.list();
+      expect(list).toEqual([]);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("repositoryRegistry.list() returns saved records in id order", async () => {
+    const tmp = await makeTempDir();
+    try {
+      const repo = new FileRepositoryRegistry(tmp);
+      const r2: RepositoryRecord = {
+        version: 1 as const,
+        id: "repo-002",
+        name: "repo 2",
+        rootUri: "file:///workspace/repo2",
+        defaultBranch: "main",
+        labels: []
+      };
+      const r1: RepositoryRecord = {
+        version: 1 as const,
+        id: "repo-001",
+        name: "repo 1",
+        rootUri: "file:///workspace/repo1",
+        defaultBranch: "main",
+        labels: []
+      };
+
+      await repo.save(r2);
+      await repo.save(r1);
+
+      const list = await repo.list();
+      expect(list.map((r) => r.id)).toEqual(["repo-001", "repo-002"]);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("planRegistry.list() returns empty array and saved records", async () => {
+    const tmp = await makeTempDir();
+    try {
+      const plans = new FilePlanRegistry(tmp);
+      const empty = await plans.list();
+      expect(empty).toEqual([]);
+
+      const p1: PlanRecord = {
+        version: 1 as const,
+        id: "plan-001",
+        title: "Test Plan",
+        goal: "test goal",
+        status: "draft" as const,
+        repositories: [
+          {
+            repositoryId: "repo-001",
+            role: "executable" as const,
+            access: "read_write" as const,
+            mountAlias: "main"
+          }
+        ],
+        primaryExecutableRepositoryId: "repo-001",
+        graphSource: "digraph G { start -> exit }",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z"
+      };
+
+      await plans.save(p1);
+      const list = await plans.list();
+      expect(list.map((p) => p.id)).toEqual(["plan-001"]);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("runRegistry.list() returns all runs regardless of status and listActiveRuns filters", async () => {
+    const tmp = await makeTempDir();
+    try {
+      const runs = new FileRunRegistry(tmp);
+
+      const fixtures: RunRecord[] = [
+        {
+          version: 1 as const,
+          id: "run-001",
+          planId: "plan-001",
+          status: "queued" as const,
+          attempt: 1,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z"
+        },
+        {
+          version: 1 as const,
+          id: "run-002",
+          planId: "plan-001",
+          status: "running" as const,
+          attempt: 1,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z"
+        },
+        {
+          version: 1 as const,
+          id: "run-003",
+          planId: "plan-001",
+          status: "paused" as const,
+          attempt: 1,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z"
+        },
+        {
+          version: 1 as const,
+          id: "run-004",
+          planId: "plan-001",
+          status: "completed" as const,
+          attempt: 1,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z"
+        },
+        {
+          version: 1 as const,
+          id: "run-005",
+          planId: "plan-001",
+          status: "failed" as const,
+          attempt: 1,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z"
+        },
+        {
+          version: 1 as const,
+          id: "run-006",
+          planId: "plan-001",
+          status: "canceled" as const,
+          attempt: 1,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z"
+        }
+      ];
+
+      for (const f of fixtures) {
+        await runs.save(f);
+      }
+
+      const all = await runs.list();
+      expect(all.map((r) => r.id)).toEqual(fixtures.map((f) => f.id));
+
+      const active = await runs.listActiveRuns();
+      expect(active.map((r) => r.id)).toEqual([
+        "run-001",
+        "run-002",
+        "run-003"
+      ]);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `listActiveRuns(): Promise<RunRecord[]>` to the `RunRegistry` interface and `FileRunRegistry` implementation (filters on `queued | running | paused` statuses using a typed Set)
- Adds barrel `index.ts` re-exports for `RepositoryRegistry`, `FileRepositoryRegistry`, `PlanRegistry`, `FilePlanRegistry`, `RunRegistry`, `FileRunRegistry`
- Adds 4 integration tests in `packages/extension/test/storage/storage-read-surface.test.ts` (empty list, id-sorted list, plan list, active-run filtering across all 6 statuses) using real temp dirs
- Updates `packages/extension/test/smoke/activation.test.ts` mock to include `listActiveRuns()`

## M3 Lane
L1 — Storage Read Surface (Wave 1)

## Tests
125 passing. All extension tests pass.