### PR TITLE
fix(preview): mount app to #root in ui-preview.html (GLA-76)

### DIFF
--- a/.sisyphus/drafts/next-phases.md
+++ b/.sisyphus/drafts/next-phases.md
@@ -3,6 +3,7 @@
 ## What We Know (from roadmap + progress tracker + git history)
 
 ### Completed Milestones
+
 - **M0** (0.1-0.6): Repo setup, workspace scaffold, CI skeleton ✅
 - **M1**: Shared contracts core, CI hardening, webview shell, extension runtime spine ✅
 - **M2**: Backend spine — DOT validator, FileEventLog, GitWorktreeManager, SnapshotProjector, services wiring ✅
@@ -12,10 +13,12 @@
 - **M5**: Release readiness — PR #29 merged. esbuild bundling, VSIX packaging, startup error boundary, CI packaging validation ✅
 
 ### In Progress
+
 - **wire-orchestration** plan: Task 1 (gateway wiring) code done but uncommitted. Tasks 2-7 pending.
 - **e2e-regression-tests** plan: 12/89 tasks done (was previous boulder, now paused)
 
 ### v1 Feature Requirements (from roadmap)
+
 - Repository-first dashboard
 - One executable repository per plan
 - Create, run, resume, cancel, and retry plans and milestones
@@ -24,12 +27,14 @@
 - Internal roles: orchestrator, planner, implementer, reviewer
 
 ### Known Gaps (from readiness audit)
+
 1. startOrchestration is placeholder in runtime.ts (wire-orchestration covers this)
 2. Model gateway defaults to NoOp (wire-orchestration covers this)
 3. Chat commands are placeholders (wire-orchestration covers this)
 4. No structured lifecycle logging (wire-orchestration covers this)
 
 ## Open Questions (awaiting explore agents)
+
 - Does DOT graph execution exist? (not just validation)
 - Does the webview render graphs visually?
 - What's the state of timeline/logs/artifacts in the UI?
@@ -37,5 +42,6 @@
 - Is worktree management wired into orchestration?
 
 ## Deliverables
+
 1. Updated `docs/plans/progress-tracker.md` reflecting current state
 2. New plan in `.sisyphus/plans/v1-next-phases.md` covering remaining v1 work

--- a/.sisyphus/plans/e2e-regression-tests.md
+++ b/.sisyphus/plans/e2e-regression-tests.md
@@ -1,6 +1,7 @@
 # E2E Regression Test Suite for Attractor VS Code Extension
 
 ## TL;DR
+
 > **Summary**: Build a comprehensive Playwright + vitest E2E regression test suite covering the Attractor webview dashboard (4 surfaces), extension-webview bridge messaging, chat participant, orchestration loop, and event sourcing. Wave 1 includes a proof-of-concept spike to validate Playwright can access VS Code's double-nested webview iframes before committing to the approach.
 > **Deliverables**: `playwright.config.ts`, VS Code launcher + webview frame helpers, 9 Playwright E2E tests, 16 vitest integration tests, CI job definition, `data-testid` additions to surface components
 > **Effort**: Large
@@ -10,9 +11,11 @@
 ## Context
 
 ### Original Request
+
 Build a full suite of E2E tests that regression-test the Attractor VS Code extension from inside VS Code. Use Playwright to control the webview. Cover all happy paths, edge cases, and exceptions.
 
 ### Interview Summary
+
 - **Both test layers**: Playwright UI (Waves 0-5) + vitest integration (Waves 6-8)
 - **OrchestrationLoop**: Test with mock ModelGateway despite `startOrchestration` being a placeholder
 - **data-testid strategy**: Add testids to surface content elements as Wave 0 prep
@@ -20,6 +23,7 @@ Build a full suite of E2E tests that regression-test the Attractor VS Code exten
 - **Test location**: Playwright E2E tests in root `test/e2e/`; vitest integration tests in `packages/extension/test/integration/` and `packages/webview/test/integration/` (discoverable by existing vitest project entries)
 
 ### Metis Review (gaps addressed)
+
 1. **Double-nested iframe** (Gap 1): VS Code webviews are double-nested iframes (`<iframe class="webview">` → inner `<iframe>`). Wave 1 frame finder must account for this.
 2. **`timeline.update` is dead code** (Gap 2): Removed from test scope. `graph.update` and `orchestration.state` dispatch to store but NO component renders them — Wave 5 tests store dispatch only, NOT visual rendering.
 3. **`run.state` has no bridge trigger** (Gap 3): RunSurface tests must inject synthetic `run.state` messages via postMessage, not via bridge commands.
@@ -29,24 +33,27 @@ Build a full suite of E2E tests that regression-test the Attractor VS Code exten
 7. **CI job definition** (Gap 7): Wave 1 creates an `e2e` job in `.github/workflows/ci.yml` with Xvfb, matrix (ubuntu+windows), artifact upload for traces.
 
 ### Flakiness Mitigations (from Metis)
-| Vector | Mitigation |
-|--------|------------|
-| VS Code launch timing | `electronApp.firstWindow()` with 30s timeout + explicit `waitForSelector` on activity bar |
-| Webview panel activation | Wait for outer iframe → inner iframe → `[data-testid]` chain with explicit `waitFor` |
+
+| Vector                        | Mitigation                                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------- |
+| VS Code launch timing         | `electronApp.firstWindow()` with 30s timeout + explicit `waitForSelector` on activity bar               |
+| Webview panel activation      | Wait for outer iframe → inner iframe → `[data-testid]` chain with explicit `waitFor`                    |
 | `postMessage` delivery timing | Use web-first assertions (`toBeVisible`, `toHaveText`) which auto-retry — NEVER `page.waitForTimeout()` |
-| Double-iframe load race | Always use `frameLocator` chain with `waitFor` on known element inside innermost frame |
-| CI display server | `xvfb-run` on Linux, native on Windows |
-| Extension activation race | Wait for extension activation via output channel or command availability before testing |
-| Temp dir isolation | `mkdtemp` with unique prefix per test, cleanup in `afterEach` |
-| Parallel test interference | `workers: 1` in Playwright config (serial execution) |
-| CSP blocking | All assertions are DOM-based, no JS injection into webview |
+| Double-iframe load race       | Always use `frameLocator` chain with `waitFor` on known element inside innermost frame                  |
+| CI display server             | `xvfb-run` on Linux, native on Windows                                                                  |
+| Extension activation race     | Wait for extension activation via output channel or command availability before testing                 |
+| Temp dir isolation            | `mkdtemp` with unique prefix per test, cleanup in `afterEach`                                           |
+| Parallel test interference    | `workers: 1` in Playwright config (serial execution)                                                    |
+| CSP blocking                  | All assertions are DOM-based, no JS injection into webview                                              |
 
 ## Work Objectives
 
 ### Core Objective
+
 Establish a maintainable, deterministic E2E regression test suite that catches regressions in the Attractor webview dashboard, extension-webview bridge, and extension-host integrations before they reach production.
 
 ### Deliverables
+
 1. `data-testid` attributes on all surface content elements and toast bar
 2. Degraded-mode error rendering fix in `OverviewSurface.tsx`
 3. `playwright.config.ts` with VS Code Electron configuration
@@ -57,6 +64,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
 8. Test fixtures validated against Zod schemas
 
 ### Definition of Done (verifiable conditions)
+
 - `npx playwright test` passes all E2E tests (0 failures)
 - `pnpm test` passes all vitest tests including new integration tests (0 failures)
 - `pnpm typecheck && pnpm lint` pass with 0 errors
@@ -65,6 +73,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
 - Evidence screenshots/traces saved to `.sisyphus/evidence/` on failure
 
 ### Must Have
+
 - Proof-of-concept spike validating Playwright webview access (Wave 1, hard blocker)
 - Per-file VS Code instance isolation
 - All 4 surface rendering tests (overview, repository, plan, run)
@@ -76,6 +85,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
 - OrchestrationLoop integration test with mock ModelGateway
 
 ### Must NOT Have (guardrails)
+
 - DO NOT create Playwright tests for graph/orchestration visual rendering (no UI components exist for these)
 - DO NOT test `timeline.update` (dead code — no handler in bridge or message-dispatch)
 - DO NOT duplicate existing unit test coverage — each vitest integration test must document what it covers that unit tests don't
@@ -87,7 +97,9 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
 - DO NOT mark `run.resume`/`run.retry` tests as passing — mark as `test.fixme()` since behavior will change
 
 ## Verification Strategy
+
 > ZERO HUMAN INTERVENTION — all verification is agent-executed.
+
 - Test decision: TDD (RED-GREEN-REFACTOR) for Waves 1-8; Wave 0 is prep work verified by existing tests passing
 - QA policy: Every task has agent-executed scenarios with specific selectors and expected outcomes
 - Evidence: `.sisyphus/evidence/task-{N}-{slug}.{ext}`
@@ -98,65 +110,73 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
 ### Parallel Execution Waves
 
 **Wave 0** (Foundation prep — 2 tasks):
+
 - Task 1: Add `data-testid` to surface content elements (`visual-engineering`)
 - Task 2: Fix degraded-mode error rendering in OverviewSurface (`quick`)
 
 **Wave 1** (Test infrastructure — 3 tasks):
+
 - Task 3: Proof-of-concept spike — validate Playwright webview access (`deep`)
 - Task 4: Playwright config + VS Code launcher + frame finder utilities (`unspecified-high`)
 - Task 5: CI job definition for E2E tests (`quick`)
 
 **Wave 2** (Handshake & degraded mode — 1 task):
+
 - Task 6: Handshake flow + degraded mode E2E tests (`unspecified-high`)
 
 **Wave 3** (Surface rendering — 2 tasks):
+
 - Task 7: Overview + Repository surface rendering tests — 2 Playwright tests (`unspecified-high`)
 - Task 8: Plan + Run surface rendering tests — 2 Playwright tests (`unspecified-high`)
 
 **Wave 4** (Bridge commands + toast rendering — 2 tasks):
+
 > **Architecture decision**: Bridge command logic (plan.run, run.cancel, plan.create etc.) is tested via **vitest** calling `handleWebviewMessage()` directly — a pure function at `packages/extension/src/dashboard/bridge.ts:48`. This avoids the CSP/trigger mechanism problem: the webview CSP (`default-src 'none'; script-src 'nonce-...'`) blocks JS injection, and no UI buttons exist to trigger these commands. Playwright tests in this wave verify only **toast rendering** by injecting outbound `toast` messages via the message helper (posting to the webview window from Electron page context, not subject to webview CSP).
+
 - Task 9: Bridge command flow integration tests — **vitest** (`unspecified-high`)
 - Task 10: Bridge validation + toast rendering E2E tests — 2 Playwright tests (`unspecified-high`)
 
 **Wave 5** (Store dispatch — 1 task):
+
 - Task 11: Graph + orchestration store dispatch verification — vitest (`unspecified-high`)
 
 **Wave 6-8** (Extension-host integration — 3 tasks, parallelizable with Waves 2-5):
+
 - Task 12: Chat participant registration wiring — vitest (`unspecified-high`)
 - Task 13: OrchestrationLoop integration with mock ModelGateway — vitest (`unspecified-high`)
 - Task 14: Event log + snapshot projector full cycle — vitest (`unspecified-high`)
 
 ### Dependency Matrix
 
-| Task | Depends On | Blocks |
-|------|-----------|--------|
-| 1 (testids) | — | 6, 7, 8, 10 |
-| 2 (error fix) | — | 6 |
-| 3 (spike) | — | 4 |
-| 4 (infra) | 3 | 5, 6, 7, 8, 10 |
-| 5 (CI) | 4 | — |
-| 6 (handshake) | 1, 2, 4 | — |
-| 7 (overview+repo) | 1, 4 | — |
-| 8 (plan+run) | 1, 4 | — |
-| 9 (bridge cmds vitest) | — | — |
-| 10 (validation+toasts) | 1, 4 | — |
-| 11 (store dispatch) | — | — |
-| 12 (chat) | — | — |
-| 13 (orch loop) | — | — |
-| 14 (event sourcing) | — | — |
+| Task                   | Depends On | Blocks         |
+| ---------------------- | ---------- | -------------- |
+| 1 (testids)            | —          | 6, 7, 8, 10    |
+| 2 (error fix)          | —          | 6              |
+| 3 (spike)              | —          | 4              |
+| 4 (infra)              | 3          | 5, 6, 7, 8, 10 |
+| 5 (CI)                 | 4          | —              |
+| 6 (handshake)          | 1, 2, 4    | —              |
+| 7 (overview+repo)      | 1, 4       | —              |
+| 8 (plan+run)           | 1, 4       | —              |
+| 9 (bridge cmds vitest) | —          | —              |
+| 10 (validation+toasts) | 1, 4       | —              |
+| 11 (store dispatch)    | —          | —              |
+| 12 (chat)              | —          | —              |
+| 13 (orch loop)         | —          | —              |
+| 14 (event sourcing)    | —          | —              |
 
 ### Agent Dispatch Summary
 
-| Wave | Tasks | Categories |
-|------|-------|------------|
-| 0 | 2 (Tasks 1-2) | visual-engineering, quick |
-| 1 | 3 (Tasks 3-5) | deep, unspecified-high, quick |
-| 2 | 1 (Task 6) | unspecified-high |
-| 3 | 2 (Tasks 7-8) | unspecified-high |
-| 4 | 2 (Tasks 9-10) | unspecified-high |
-| 5 | 1 (Task 11) | unspecified-high |
-| 6-8 | 3 (Tasks 12-14) | unspecified-high |
-| **Total** | **14 tasks** | |
+| Wave      | Tasks           | Categories                    |
+| --------- | --------------- | ----------------------------- |
+| 0         | 2 (Tasks 1-2)   | visual-engineering, quick     |
+| 1         | 3 (Tasks 3-5)   | deep, unspecified-high, quick |
+| 2         | 1 (Task 6)      | unspecified-high              |
+| 3         | 2 (Tasks 7-8)   | unspecified-high              |
+| 4         | 2 (Tasks 9-10)  | unspecified-high              |
+| 5         | 1 (Task 11)     | unspecified-high              |
+| 6-8       | 3 (Tasks 12-14) | unspecified-high              |
+| **Total** | **14 tasks**    |                               |
 
 ## TODOs
 
@@ -232,6 +252,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   - [ ] No behavior changes — only attribute additions
 
   **QA Scenarios**:
+
   ```
   Scenario: All testids present in source
     Tool: Bash
@@ -286,6 +307,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   - [ ] `pnpm typecheck && pnpm lint && pnpm test` all pass
 
   **QA Scenarios**:
+
   ```
   Scenario: Error banner renders with error payload
     Tool: Bash
@@ -345,6 +367,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   - [ ] Message injection feasibility documented (yes/no with details)
 
   **QA Scenarios**:
+
   ```
   Scenario: Spike successfully reads webview DOM
     Tool: Bash
@@ -367,16 +390,16 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
 
   **What to do**:
   Using findings from Task 3, create permanent test infrastructure:
-
   1. **`playwright.config.ts`** (root):
+
      ```typescript
-     import { defineConfig } from '@playwright/test';
+     import { defineConfig } from "@playwright/test";
      export default defineConfig({
-       testDir: 'test/e2e',
+       testDir: "test/e2e",
        timeout: 60_000,
        retries: process.env.CI ? 1 : 0,
        workers: 1,
-       use: { trace: 'on-first-retry' },
+       use: { trace: "on-first-retry" }
      });
      ```
 
@@ -430,6 +453,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   - [ ] No `page.waitForTimeout()` in any file
 
   **QA Scenarios**:
+
   ```
   Scenario: Smoke test passes
     Tool: Bash
@@ -491,6 +515,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   - [ ] `pnpm lint` passes (YAML valid)
 
   **QA Scenarios**:
+
   ```
   Scenario: CI YAML is valid
     Tool: Bash
@@ -552,6 +577,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   - [ ] Test 2 verifies error banner visibility and text content
 
   **QA Scenarios**:
+
   ```
   Scenario: Normal handshake completes
     Tool: Bash
@@ -621,6 +647,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   - [ ] Fixtures stored in `test/e2e/fixtures/`
 
   **QA Scenarios**:
+
   ```
   Scenario: Overview populated rendering
     Tool: Bash
@@ -689,6 +716,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   - [ ] Fixtures stored in `test/e2e/fixtures/`
 
   **QA Scenarios**:
+
   ```
   Scenario: Plan populated rendering
     Tool: Bash
@@ -713,7 +741,6 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   Create `packages/extension/test/integration/bridge-commands.test.ts` (vitest) testing the bridge command handler logic. This tests `handleWebviewMessage()` directly — a pure function that takes a parsed message, services, panel mock, and optional orchestration context. **This replaces the original Playwright approach** because the webview CSP blocks JS injection and no UI buttons trigger these commands.
 
   **Tests** (5 tests):
-
   1. `test('plan.run: valid planId sends orchestration-started toast')`:
      - Create mock `StorageServices`, mock `WebviewPanelLike` that records `postMessage` calls
      - Call `handleWebviewMessage({ version: 1, requestId: "r1", type: "plan.run", payload: { planId: "plan-001" } }, services, panel)`
@@ -767,6 +794,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   - [ ] No Playwright imports — this is a vitest test
 
   **QA Scenarios**:
+
   ```
   Scenario: plan.run valid sends correct toast
     Tool: Bash
@@ -834,6 +862,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   - [ ] No `page.waitForTimeout()` calls
 
   **QA Scenarios**:
+
   ```
   Scenario: Malformed messages don't crash webview
     Tool: Bash
@@ -858,7 +887,6 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   Create `packages/webview/test/integration/store-dispatch.test.ts` testing that `graph.update` and `orchestration.state` messages are correctly dispatched through `messageDispatch` into the store. These messages dispatch to store but NO component renders them — so this is a store-level integration test, not a UI test.
 
   **Tests** (3 tests):
-
   1. `test('graph.update: dispatches graphUpdate to store')`:
      - Create a store via `createStore(createInitialState())`
      - Call `messageDispatch(store, { version: 1, type: "graph.update", payload: { nodeId: "n1", status: "complete" } })`
@@ -900,6 +928,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   - [ ] No tests for `timeline.update` (dead code)
 
   **QA Scenarios**:
+
   ```
   Scenario: graph.update dispatches to store
     Tool: Bash
@@ -924,7 +953,6 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   Create `packages/extension/test/integration/chat-participant.test.ts` testing chat participant registration via the extension activation path.
 
   **Tests** (2 tests):
-
   1. `test('chat participant registers with correct ID')`:
      - Import and call the relevant registration logic
      - Assert the participant was registered with ID `"attractor.attractor"` (matching `PARTICIPANT_ID` constant at `packages/extension/src/chat/attractor-chat-participant.ts:41`)
@@ -958,6 +986,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   - [ ] No live Copilot API calls
 
   **QA Scenarios**:
+
   ```
   Scenario: Participant ID matches constant
     Tool: Bash
@@ -982,7 +1011,6 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   Create `packages/extension/test/integration/orchestration-loop.test.ts` testing the `OrchestrationLoop` class with a mock `ModelGateway`.
 
   **Tests** (3 tests):
-
   1. `test('orchestration loop: starts and progresses through phases')`:
      - Create `OrchestrationLoop` with `NoOpModelGateway` (from `packages/extension/src/application/ports.ts`)
      - Start a plan run with a simple DOT graph
@@ -1026,6 +1054,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   - [ ] No shared state between tests
 
   **QA Scenarios**:
+
   ```
   Scenario: Loop progresses through phases
     Tool: Bash
@@ -1050,7 +1079,6 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   Create `packages/extension/test/integration/event-sourcing.test.ts` testing the full event sourcing cycle: append events to `FileEventLog`, then project them via `SnapshotProjector`.
 
   **Tests** (3 tests):
-
   1. `test('full cycle: append events, list by run, project snapshot')`:
      - Create `FileEventLog` with a temp dir (via `mkdtemp`)
      - Append >=5 events for a single run (start, milestone-begin, node-complete, milestone-end, run-complete)
@@ -1095,6 +1123,7 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
   - [ ] No shared state between tests
 
   **QA Scenarios**:
+
   ```
   Scenario: Full event sourcing cycle
     Tool: Bash
@@ -1118,35 +1147,35 @@ Establish a maintainable, deterministic E2E regression test suite that catches r
 > **Never mark F1-F4 as checked before getting user's okay.** Rejection or user feedback → fix → re-run → present again → wait for okay.
 
 - [x] F1. Plan Compliance Audit — oracle
-  Verify every task matches its acceptance criteria. Check that all 14 tasks were implemented. Verify test count stays within the <=15 Playwright test cap (**current count: 9 Playwright tests**). Confirm no `page.waitForTimeout()` calls exist. Confirm `workers: 1` in playwright.config.ts.
+      Verify every task matches its acceptance criteria. Check that all 14 tasks were implemented. Verify test count stays within the <=15 Playwright test cap (**current count: 9 Playwright tests**). Confirm no `page.waitForTimeout()` calls exist. Confirm `workers: 1` in playwright.config.ts.
 
 - [x] F2. Code Quality Review — unspecified-high
-  Review all new test files for: proper cleanup (afterEach/afterAll), no hardcoded timeouts, consistent use of `data-testid` selectors, fixture data validated against Zod schemas, meaningful test descriptions.
+      Review all new test files for: proper cleanup (afterEach/afterAll), no hardcoded timeouts, consistent use of `data-testid` selectors, fixture data validated against Zod schemas, meaningful test descriptions.
 
 - [x] F3. Real Manual QA — unspecified-high (+ playwright if UI)
-  Execute `npx playwright test` and `pnpm test` on the full suite. Capture pass/fail counts. Verify CI job definition by dry-running with `act` or inspecting YAML structure. Take screenshots of any failures.
+      Execute `npx playwright test` and `pnpm test` on the full suite. Capture pass/fail counts. Verify CI job definition by dry-running with `act` or inspecting YAML structure. Take screenshots of any failures.
 
 - [x] F4. Scope Fidelity Check — deep
-  Compare implementation against this plan: verify no scope creep (no extra production changes beyond Wave 0), no duplicate unit test coverage in Waves 6-8, no tests for dead code (timeline.update, graph/orchestration rendering). Verify each vitest integration test has a comment explaining what it covers that unit tests don't.
+      Compare implementation against this plan: verify no scope creep (no extra production changes beyond Wave 0), no duplicate unit test coverage in Waves 6-8, no tests for dead code (timeline.update, graph/orchestration rendering). Verify each vitest integration test has a comment explaining what it covers that unit tests don't.
 
 ## Commit Strategy
 
-| Wave | Commit # | Message | Files |
-|------|----------|---------|-------|
-| 0 | 1 | `test(prep): add data-testid attributes to surface components and toast bar` | `packages/webview/src/overview/OverviewSurface.tsx`, `packages/webview/src/repository/RepositorySurface.tsx`, `packages/webview/src/plan/PlanSurface.tsx`, `packages/webview/src/run/RunSurface.tsx`, `packages/webview/src/app/App.tsx` |
-| 0 | 2 | `fix(webview): render degraded-mode error in OverviewSurface` | `packages/webview/src/overview/OverviewSurface.tsx`, `packages/webview/src/overview/model.ts` |
-| 1 | 3 | `test(e2e): add playwright config, VS Code launcher, and frame finder utilities` | `playwright.config.ts`, `test/e2e/helpers/launch.ts`, `test/e2e/helpers/webview-frame.ts`, `package.json` |
-| 1 | 4 | `test(e2e): add smoke test - launch VS Code, open panel, verify overview surface` | `test/e2e/smoke.test.ts` |
-| 1 | 5 | `ci: add e2e job with Xvfb and trace artifacts` | `.github/workflows/ci.yml` |
-| 2 | 6 | `test(e2e): handshake flow and degraded mode` | `test/e2e/handshake.test.ts` |
-| 3 | 7 | `test(e2e): overview and repository surface rendering` | `test/e2e/surfaces-overview-repository.test.ts`, `test/e2e/fixtures/` |
-| 3 | 8 | `test(e2e): plan and run surface rendering` | `test/e2e/surfaces-plan-run.test.ts`, `test/e2e/fixtures/` |
-| 4 | 9 | `test(integration): bridge command flows via handleWebviewMessage` | `packages/extension/test/integration/bridge-commands.test.ts` |
-| 4 | 10 | `test(e2e): bridge validation resilience and toast rendering` | `test/e2e/bridge-validation-and-toasts.test.ts` |
-| 5 | 11 | `test(integration): graph and orchestration store dispatch` | `packages/webview/test/integration/store-dispatch.test.ts` |
-| 6 | 12 | `test(integration): chat participant registration wiring` | `packages/extension/test/integration/chat-participant.test.ts` |
-| 7 | 13 | `test(integration): OrchestrationLoop with mock ModelGateway` | `packages/extension/test/integration/orchestration-loop.test.ts` |
-| 8 | 14 | `test(integration): event log + snapshot projector full cycle` | `packages/extension/test/integration/event-sourcing.test.ts` |
+| Wave | Commit # | Message                                                                           | Files                                                                                                                                                                                                                                    |
+| ---- | -------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0    | 1        | `test(prep): add data-testid attributes to surface components and toast bar`      | `packages/webview/src/overview/OverviewSurface.tsx`, `packages/webview/src/repository/RepositorySurface.tsx`, `packages/webview/src/plan/PlanSurface.tsx`, `packages/webview/src/run/RunSurface.tsx`, `packages/webview/src/app/App.tsx` |
+| 0    | 2        | `fix(webview): render degraded-mode error in OverviewSurface`                     | `packages/webview/src/overview/OverviewSurface.tsx`, `packages/webview/src/overview/model.ts`                                                                                                                                            |
+| 1    | 3        | `test(e2e): add playwright config, VS Code launcher, and frame finder utilities`  | `playwright.config.ts`, `test/e2e/helpers/launch.ts`, `test/e2e/helpers/webview-frame.ts`, `package.json`                                                                                                                                |
+| 1    | 4        | `test(e2e): add smoke test - launch VS Code, open panel, verify overview surface` | `test/e2e/smoke.test.ts`                                                                                                                                                                                                                 |
+| 1    | 5        | `ci: add e2e job with Xvfb and trace artifacts`                                   | `.github/workflows/ci.yml`                                                                                                                                                                                                               |
+| 2    | 6        | `test(e2e): handshake flow and degraded mode`                                     | `test/e2e/handshake.test.ts`                                                                                                                                                                                                             |
+| 3    | 7        | `test(e2e): overview and repository surface rendering`                            | `test/e2e/surfaces-overview-repository.test.ts`, `test/e2e/fixtures/`                                                                                                                                                                    |
+| 3    | 8        | `test(e2e): plan and run surface rendering`                                       | `test/e2e/surfaces-plan-run.test.ts`, `test/e2e/fixtures/`                                                                                                                                                                               |
+| 4    | 9        | `test(integration): bridge command flows via handleWebviewMessage`                | `packages/extension/test/integration/bridge-commands.test.ts`                                                                                                                                                                            |
+| 4    | 10       | `test(e2e): bridge validation resilience and toast rendering`                     | `test/e2e/bridge-validation-and-toasts.test.ts`                                                                                                                                                                                          |
+| 5    | 11       | `test(integration): graph and orchestration store dispatch`                       | `packages/webview/test/integration/store-dispatch.test.ts`                                                                                                                                                                               |
+| 6    | 12       | `test(integration): chat participant registration wiring`                         | `packages/extension/test/integration/chat-participant.test.ts`                                                                                                                                                                           |
+| 7    | 13       | `test(integration): OrchestrationLoop with mock ModelGateway`                     | `packages/extension/test/integration/orchestration-loop.test.ts`                                                                                                                                                                         |
+| 8    | 14       | `test(integration): event log + snapshot projector full cycle`                    | `packages/extension/test/integration/event-sourcing.test.ts`                                                                                                                                                                             |
 
 ## Success Criteria
 

--- a/.sisyphus/plans/m4-copilot-orchestration.md
+++ b/.sisyphus/plans/m4-copilot-orchestration.md
@@ -28,11 +28,13 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 ## Existing Codebase Snapshot (main branch)
 
 ### Package Structure
+
 - `packages/shared/` — Zod schemas, contracts (400 lines in `contracts/index.ts`)
 - `packages/extension/` — VS Code extension (32 source files across runtime, dashboard, storage, worktrees, graph)
 - `packages/webview/` — Preact+Tailwind webview (33 source files across surfaces, store, components)
 
 ### Key Extension Seams
+
 - `runtime.ts` — `activateAttractor(context, commandsApi, dependencies)` with `StorageServices`, `WebviewViewProvider` registration, `onWebviewMessage` handler
 - `dashboard/bridge.ts` — `handleWebviewMessage()` dispatches query routes (ready, repository.open, milestone.open, graph.focus) and command no-ops (plan.create, plan.run, run.resume, run.cancel, run.retry)
 - `extension.ts` — passes `commands` and `WindowApiLike` to `activateAttractor`. Uses `require("vscode")` workaround due to old vscode types package
@@ -40,6 +42,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - `dashboard/webview-provider.ts` — `AttractorViewProvider` with `WebviewPostTarget` pattern
 
 ### Shared Contracts Already Present
+
 - `RoleSchema` = enum ["orchestrator", "planner", "implementer", "reviewer"] — ALREADY EXISTS
 - `RunRecordSchema` with `attempt` field (no `graphId`/`worktreeId`/`startedAt`/`completedAt`)
 - `WebviewOutboundMessageTypeSchema` = enum ["overview.state", "repository.state", "plan.state", "run.state", "timeline.update", "graph.update", "toast"]
@@ -47,6 +50,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - `NodeStatusSchema` = enum ["queued", "running", "blocked", "failed", "succeeded", "canceled"]
 
 ### Test Infrastructure
+
 - 37 test files, ~319 tests
 - Vitest runner, fixture-based contract tests
 - Fixtures under `test/fixtures/contracts/**`
@@ -62,6 +66,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 **Inputs:** Current `RoleSchema`, `RunRecord`, outbound message contracts.
 
 **Outputs:**
+
 - `AgentRoleStatusSchema` = enum ["done", "running", "waiting", "failed", "skipped"]
 - `AgentRolePhaseSchema` = object { role: RoleSchema, status: AgentRoleStatusSchema, taskSummary?: string, errorLabel?: string }
 - `OrchestrationStatePayloadSchema` = object { runId, milestoneIndex, milestoneCount, milestoneName, phases: AgentRolePhaseSchema[4] }
@@ -74,6 +79,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - `RunRecordSchema` += optional `graphId`, `worktreeId`, `startedAt`, `completedAt`
 
 **Tests:**
+
 - Schema parse/reject tests for all new orchestration payloads (valid + invalid)
 - Updated run record tests accept new optional fields
 - Updated webview message tests accept "orchestration.state"
@@ -81,6 +87,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - Fixture files if pattern requires
 
 **Files Modified:**
+
 - `packages/shared/src/contracts/index.ts`
 - `packages/shared/test/contracts/run-record.test.ts`
 - `packages/shared/test/contracts/webview-message.test.ts`
@@ -88,6 +95,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - NEW: `test/fixtures/contracts/runs/valid/with-optional-m4-fields.json` (if fixture pattern used)
 
 **Acceptance:**
+
 - All new payloads parse correctly with valid data
 - All new payloads reject invalid data
 - Existing payloads still parse unchanged
@@ -105,6 +113,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 **Inputs:** Slice 1 complete.
 
 **Outputs:**
+
 - Replace `"vscode": "^1.1.37"` devDep with `"@types/vscode": "^1.103.0"` in extension package.json
 - Remove `require("vscode")` workaround from `extension.ts`; use proper static imports
 - Add `chatParticipants` contribution to extension `package.json`
@@ -112,15 +121,18 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - Add commands: `attractor.run.start`, `attractor.run.cancel`, `attractor.plan.create`
 
 **Tests:**
+
 - Activation smoke tests still pass
 - TypeScript compiles cleanly with new types (typecheck is the test)
 
 **Files Modified:**
+
 - `packages/extension/package.json`
 - `packages/extension/src/extension.ts`
 - `packages/extension/test/smoke/activation.test.ts` (if assertions need updating)
 
 **Acceptance:**
+
 - `pnpm typecheck` succeeds with `@types/vscode` and chat/lm APIs available
 - `pnpm test` passes — no regressions
 - Dashboard activation still works
@@ -137,6 +149,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 **Inputs:** Slice 1 complete.
 
 **Outputs:**
+
 - `ModelGateway` interface: `send(messages, options) => Promise<string>`, `stream(messages, onChunk, options) => Promise<void>`
 - `ModelMessage` type: `{ role: "system" | "user" | "assistant", content: string }`
 - `ModelRequestOptions` type: `{ modelFamily?: string, maxTokens?: number, temperature?: number, signal?: AbortSignal }`
@@ -144,16 +157,19 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - Barrel export
 
 **Tests:**
+
 - `NoOpModelGateway.send()` returns empty string
 - `NoOpModelGateway.stream()` completes without calling onChunk
 - Type-level coverage for `ModelMessage` and `ModelRequestOptions`
 
 **Files Created:**
+
 - `packages/extension/src/application/ports.ts`
 - `packages/extension/src/application/index.ts`
 - `packages/extension/test/application/ports.test.ts`
 
 **Acceptance:**
+
 - Clean interface that downstream slices can depend on
 - No VS Code imports in this file
 - `pnpm typecheck && pnpm test` passes
@@ -169,6 +185,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 **Inputs:** Slices 1 and 3 complete.
 
 **Outputs:**
+
 - 8 functions:
   - `buildOrchestratorSystemPrompt(context)` / `buildOrchestratorUserMessage(context)`
   - `buildPlannerSystemPrompt(context)` / `buildPlannerUserMessage(context)`
@@ -178,16 +195,19 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - Returns `ModelMessage[]` arrays ready for `ModelGateway.send()`
 
 **Tests:**
+
 - 4 describe blocks (one per role), ~10 tests total
 - System prompts contain role identity, scope constraints, v1 node subset
 - User messages include milestone name, acceptance criteria, prior handoff summary
 - Deterministic: same input => same output
 
 **Files Created:**
+
 - `packages/extension/src/application/role-prompts.ts`
 - `packages/extension/test/application/role-prompts.test.ts`
 
 **Acceptance:**
+
 - Pure functions, zero side effects, no VS Code/storage imports
 - All prompts mention role identity
 - Orchestrator prompt mentions v1 node constraints
@@ -206,6 +226,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 **Inputs:** Slices 1, 3, 4 complete.
 
 **Outputs:**
+
 - Pure builder functions for each role handoff:
   - `buildOrchestratorHandoff(milestoneRecord) => OrchestratorHandoff`
   - `buildPlannerHandoff(modelResponse, milestoneId) => PlannerHandoff`
@@ -215,15 +236,18 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - Mapper: handoff payload => `ArtifactRecord` write intent (type, title, uri shape)
 
 **Tests:**
+
 - Unit tests for each handoff artifact shape
 - Contract round-trip: output validates against shared schemas
 - Malformed model response handling (graceful defaults, not crashes)
 
 **Files Created:**
+
 - `packages/extension/src/application/handoffs.ts`
 - `packages/extension/test/application/handoffs.test.ts`
 
 **Acceptance:**
+
 - Each phase can emit a stable typed handoff artifact
 - Handoff payloads validate against `OrchestratorHandoffSchema`, `PlannerHandoffSchema`, etc.
 - No VS Code dependencies, no storage side effects
@@ -239,6 +263,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 **Inputs:** Slices 2 and 3 complete.
 
 **Outputs:**
+
 - `CopilotModelGateway` implements `ModelGateway`
 - Uses `vscode.lm.selectChatModels()` for model selection
 - `send()` collects full response text from `LanguageModelChatResponse`
@@ -246,6 +271,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - `LanguageModelApiLike` seam interface for testing
 
 **Tests:**
+
 - Mocked model selection returning a stub model
 - `send()` returns concatenated text from streamed fragments
 - `stream()` calls `onChunk` for each fragment
@@ -254,10 +280,12 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - AbortSignal/CancellationToken passthrough if VS Code API supports it
 
 **Files Created:**
+
 - `packages/extension/src/copilot/copilot-model-gateway.ts`
 - `packages/extension/test/copilot/copilot-model-gateway.test.ts`
 
 **Acceptance:**
+
 - Gateway returns deterministic strings/chunks from mocked VS Code APIs
 - No live provider calls
 - Clean separation: only this file imports vscode.lm types
@@ -274,16 +302,18 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 **Inputs:** Slices 2 and 3 complete.
 
 **Outputs:**
+
 - `ChatApiLike` seam interface (testable without vscode)
 - `buildChatHandler()` that dispatches slash commands:
   - `/plan` => acknowledge plan creation intent (placeholder response)
-  - `/run` => acknowledge run start intent (placeholder response)  
+  - `/run` => acknowledge run start intent (placeholder response)
   - `/status` => report current orchestration state (or "no active run")
 - `registerChatParticipant(chatApi, handler)` wiring function
 - Runtime integration: add `ChatApiLike?` to `RuntimeDependencies`, wire in `activateAttractor`
 - Extension.ts: extract `ChatApiLike` from vscode namespace, pass to `activateAttractor`
 
 **Tests:**
+
 - Command parsing: `/plan`, `/run`, `/status` recognized correctly
 - Unknown command => helpful fallback response
 - Registration test: chat participant registered when chatApi is provided
@@ -291,6 +321,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - Activation smoke test updated for new optional dependency
 
 **Files Created/Modified:**
+
 - NEW: `packages/extension/src/chat/attractor-chat-participant.ts`
 - MODIFY: `packages/extension/src/runtime.ts`
 - MODIFY: `packages/extension/src/extension.ts`
@@ -298,6 +329,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - MODIFY: `packages/extension/test/smoke/activation.test.ts`
 
 **Acceptance:**
+
 - Participant registers cleanly with mock chat API
 - Commands are recognized deterministically in tests
 - Activation still works when chatApi is undefined (backward compat)
@@ -314,6 +346,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 **Inputs:** Slices 1, 3, 4, 5 complete.
 
 **Outputs:**
+
 - `OrchestrationLoop` class with:
   - `execute(options: OrchestrationOptions)` — drives full milestone progression
   - Options include: `modelGateway`, `milestones`, `runId`, `onStateChange`, `onHandoff`, `onError`, `signal?`
@@ -325,6 +358,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - Abort support via `AbortSignal`
 
 **Tests (deterministic, mocked model):**
+
 - `StubModelGateway` returning canned responses per role
 - Full success path: all 4 roles complete for single milestone
 - Multi-milestone: phases execute in order across milestones
@@ -336,10 +370,12 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - Topological sort correctness for milestone ordering
 
 **Files Created:**
+
 - `packages/extension/src/application/orchestration-loop.ts`
 - `packages/extension/test/application/orchestration-loop.test.ts`
 
 **Acceptance:**
+
 - Loop runs entirely under mocks
 - Emits expected phase states at each transition
 - Emits handoff artifacts between phases
@@ -358,6 +394,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 **Inputs:** Slices 6, 7, 8 complete.
 
 **Outputs:**
+
 - Inject `ModelGateway` into `RuntimeDependencies` (with `NoOpModelGateway` default)
 - `plan.run` command handler: creates `OrchestrationLoop`, starts execution
 - `run.cancel` command handler: signals abort to running loop
@@ -368,6 +405,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - Update `RunRecord` status during orchestration
 
 **Tests:**
+
 - Bridge tests: `plan.run` message triggers orchestration start (with stub gateway)
 - Bridge tests: `run.cancel` aborts running orchestration
 - Bridge tests: `plan.create` creates a plan or returns ack
@@ -376,6 +414,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - Existing bridge tests still pass unchanged
 
 **Files Modified:**
+
 - `packages/extension/src/runtime.ts`
 - `packages/extension/src/dashboard/bridge.ts`
 - `packages/extension/test/dashboard/bridge.test.ts`
@@ -383,6 +422,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - POSSIBLY NEW: `packages/extension/src/application/run-orchestrator.ts` (thin coordinator if runtime.ts would get too large)
 
 **Acceptance:**
+
 - Dashboard commands are no longer no-ops
 - A mocked run can start and emit orchestration progress to webview
 - Cancellation stops the loop
@@ -400,12 +440,14 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 **Inputs:** Slices 1 and 9 complete.
 
 **Outputs:**
+
 - `message-dispatch.ts`: handle `"orchestration.state"` message type
 - `store.ts`: add `orchestration` payload slot to store state
 - Surface component: minimal 4-role phase strip showing role name + status badge
 - Integrate into existing run surface or as standalone orchestration surface
 
 **Tests:**
+
 - Dispatch test: `orchestration.state` message sets store correctly
 - Dispatch test: returns `true` for valid orchestration state
 - Store test: orchestration payload is accessible after dispatch
@@ -413,6 +455,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - Existing dispatch tests still pass
 
 **Files Modified:**
+
 - `packages/webview/src/app/message-dispatch.ts`
 - `packages/webview/src/app/store.ts`
 - POSSIBLY NEW: `packages/webview/src/orchestration/` surface module
@@ -420,6 +463,7 @@ Decompose M4 (Copilot Orchestration) from the Attractor roadmap into 10 dependen
 - POSSIBLY NEW: `packages/webview/test/orchestration/` tests
 
 **Acceptance:**
+
 - Webview accepts `orchestration.state` and routes it to store
 - Phase strip renders deterministically in tests
 - No regressions in existing webview behavior
@@ -458,24 +502,24 @@ Slice 1 (shared contracts)
 
 ## Wave Schedule (Parallelization)
 
-| Wave | Slices | Dependencies Met |
-|------|--------|-----------------|
-| A | 1 | (none) |
-| B | 2, 3 | 1 |
-| C | 4, 6, 7 | 1+3 for 4; 2+3 for 6,7 |
-| D | 5 | 1+3+4 |
-| E | 8 | 1+3+4+5 |
-| F | 9 | 6+7+8 |
-| G | 10 | 1+9 |
+| Wave | Slices  | Dependencies Met       |
+| ---- | ------- | ---------------------- |
+| A    | 1       | (none)                 |
+| B    | 2, 3    | 1                      |
+| C    | 4, 6, 7 | 1+3 for 4; 2+3 for 6,7 |
+| D    | 5       | 1+3+4                  |
+| E    | 8       | 1+3+4+5                |
+| F    | 9       | 6+7+8                  |
+| G    | 10      | 1+9                    |
 
 ## Agent Assignment Recommendations
 
-| Role | Slices | Rationale |
-|------|--------|-----------|
-| `@ttd-planner` | 1, 4, 8 | Schema design, prompt design, loop architecture need careful acceptance criteria |
-| `@ttd-implementer` | 2, 3, 5, 6, 7, 9, 10 | Focused implementation with clear specs |
-| `@code-reviewer` | After 1, 8, 9 | Critical integration points need review |
-| `@plan-drift-reviewer` | After 9 | Final drift check before M4 declared complete |
+| Role                   | Slices               | Rationale                                                                        |
+| ---------------------- | -------------------- | -------------------------------------------------------------------------------- |
+| `@ttd-planner`         | 1, 4, 8              | Schema design, prompt design, loop architecture need careful acceptance criteria |
+| `@ttd-implementer`     | 2, 3, 5, 6, 7, 9, 10 | Focused implementation with clear specs                                          |
+| `@code-reviewer`       | After 1, 8, 9        | Critical integration points need review                                          |
+| `@plan-drift-reviewer` | After 9              | Final drift check before M4 declared complete                                    |
 
 ## Quality Gate (per slice)
 

--- a/.sisyphus/plans/m5-release-readiness.md
+++ b/.sisyphus/plans/m5-release-readiness.md
@@ -39,11 +39,13 @@ and passes packaging validation in CI.
 ### Wave 1 (no dependencies)
 
 #### Slice 1 — Extension host esbuild bundler and webview asset staging
+
 **Files**: `packages/extension/esbuild.config.mjs` (NEW), `packages/extension/package.json`,
 `packages/extension/src/runtime.ts`, root `package.json`,
 `packages/extension/test/dashboard/webview-provider.test.ts`,
 `packages/extension/test/smoke/activation.test.ts`
 **What**:
+
 1. Add `esbuild` as a devDependency to `packages/extension/package.json`
    (needed by the esbuild config below).
 2. Create an esbuild config that bundles `src/extension.ts` → `dist/bundle/extension.js`
@@ -63,17 +65,18 @@ and passes packaging validation in CI.
    Note: production mode detection is handled inside each esbuild config via
    `process.env.NODE_ENV` (defaults to production for one-shot builds, dev
    for watch mode). No POSIX-style env prefix needed in the npm script.
-**Tests**: Run the bundler, verify output file exists, verify `vscode` is not inlined,
-verify `dist/bundle/webview/webview.js` exists after bundling.
-**QA**: First build the webview bundle (prerequisite):
-`pnpm --filter @attractor/webview build:bundle`
-Then run the extension bundler:
-`node packages/extension/esbuild.config.mjs` → exit code 0.
-Run `node -e "const fs=require('fs'); const s=fs.statSync('packages/extension/dist/bundle/extension.js'); console.log(s.size); process.exit(s.size > 512000 ? 1 : 0)"` → exit 0 (< 500KB).
-Run `node -e "require('fs').statSync('packages/extension/dist/bundle/webview/webview.js')"` → no error (file exists).
-Run `pnpm typecheck && pnpm test` → all pass.
+   **Tests**: Run the bundler, verify output file exists, verify `vscode` is not inlined,
+   verify `dist/bundle/webview/webview.js` exists after bundling.
+   **QA**: First build the webview bundle (prerequisite):
+   `pnpm --filter @attractor/webview build:bundle`
+   Then run the extension bundler:
+   `node packages/extension/esbuild.config.mjs` → exit code 0.
+   Run `node -e "const fs=require('fs'); const s=fs.statSync('packages/extension/dist/bundle/extension.js'); console.log(s.size); process.exit(s.size > 512000 ? 1 : 0)"` → exit 0 (< 500KB).
+   Run `node -e "require('fs').statSync('packages/extension/dist/bundle/webview/webview.js')"` → no error (file exists).
+   Run `pnpm typecheck && pnpm test` → all pass.
 
 #### Slice 2 — `.vscodeignore` and packaging metadata
+
 **Files**: `packages/extension/.vscodeignore` (NEW), `packages/extension/package.json`,
 `packages/extension/resources/attractor-icon.png` (NEW)
 **What**: Create `.vscodeignore` excluding `src/`, `test/`, `dist/src/`, `node_modules/`,
@@ -91,6 +94,7 @@ Run `node -e "require('fs').statSync('packages/extension/.vscodeignore')"` → n
 Run `node -e "require('fs').statSync('packages/extension/resources/attractor-icon.png')"` → no error.
 
 #### Slice 3 — Startup error boundary and output channel
+
 **Files**: `packages/extension/src/runtime.ts`, `packages/extension/test/smoke/activation.test.ts`
 **What**: Wrap `activateAttractor` body in try-catch. Create an OutputChannel
 `"Attractor"` for diagnostic logging. Log: storage root resolution,
@@ -104,12 +108,14 @@ Add `OutputChannelLike` seam to `RuntimeDependencies` with signature
 `context.onWebviewMessage` in `runtime.ts` so that when `services` is null
 and the webview sends a `"ready"` message, the handler posts an
 `overview.state` response with an empty degraded payload:
+
 ```ts
 { version: 1, requestId, type: "overview.state",
   payload: { repositories: [], activeRuns: [], recentFailures: [],
              stats: { totalRepos: 0, totalPlans: 0, activeRuns: 0, pausedRuns: 0, failedRuns24h: 0 },
              error: "Storage unavailable — check output channel for details" } }
 ```
+
 This ensures the webview receives a response instead of being silently
 ignored. The `error` field is a new optional string on the existing
 `OverviewStatePayloadSchema` (in `packages/shared/src/contracts/index.ts`).
@@ -132,6 +138,7 @@ Run `pnpm test` → all existing tests pass + 5 new tests pass (verify count ≥
 Run `pnpm lint` → exit 0.
 
 #### Slice 4 — CHANGELOG.md
+
 **Files**: `CHANGELOG.md` (NEW)
 **What**: Create CHANGELOG.md with v0.1.0 entry covering M0–M4 highlights.
 Follow [Keep a Changelog](https://keepachangelog.com/) format.
@@ -142,6 +149,7 @@ Run `pnpm exec prettier --check CHANGELOG.md` → exit 0.
 ### Wave 2 (depends on Wave 1)
 
 #### Slice 5 — `vsce:package` script and VSIX validation
+
 **Files**: root `package.json`, `packages/extension/package.json`
 **Depends on**: Slice 1 (bundler + webview staging), Slice 2 (vscodeignore + metadata)
 **What**: Add `@vscode/vsce` as root devDependency.
@@ -159,6 +167,7 @@ Run `pnpm vsce:ls` → stdout includes `dist/bundle/extension.js`,
 stdout does NOT include any `.ts` source files (except `.d.ts`), no `test/` paths.
 
 #### Slice 6 — CI packaging validation
+
 **Files**: `.github/workflows/ci.yml`
 **Depends on**: Slice 5 (vsce:package)
 **What**: Add a `package-check` job that runs after `fast-checks`. It runs
@@ -170,6 +179,7 @@ piped through a shell assertion).
 **QA**: Push branch, verify CI shows green `package-check` job alongside `fast-checks`.
 
 #### Slice 7 — README and docs refresh
+
 **Files**: `README.md`, `packages/extension/package.json` (repository field)
 **Depends on**: Slice 4 (CHANGELOG exists)
 **What**: Update README milestone table through M4. Add "Getting Started" section
@@ -183,32 +193,38 @@ Run `node -e "const r=require('fs').readFileSync('README.md','utf8'); console.as
 ### Wave 3 (depends on Wave 2)
 
 #### Slice 8 — VSIX content smoke test
+
 **Files**: `test/smoke/vsix-content.test.ts` (NEW), `test/smoke/vitest.config.ts` (NEW),
 `vitest.config.ts` (MODIFY — add smoke project to `test.projects`)
 **Depends on**: Slice 5 (packaging works)
 **What**: Create `test/smoke/vitest.config.ts` following the existing
 `test/meta/vitest.config.ts` pattern:
+
 ```ts
-export default defineConfig({ test: { name: "smoke", include: ["*.test.ts"] } })
+export default defineConfig({
+  test: { name: "smoke", include: ["*.test.ts"] }
+});
 ```
+
 Add `"test/smoke/vitest.config.ts"` to root `vitest.config.ts` `test.projects` array.
 Create `test/smoke/vsix-content.test.ts` that first runs
 `pnpm build` (to ensure webview and extension bundles exist), then shells
 out to `pnpm --filter @attractor/extension exec vsce ls --no-dependencies`,
 captures stdout, and asserts:
+
 - `dist/bundle/extension.js` is listed
 - `dist/bundle/webview/webview.js` is listed
 - `dist/bundle/webview/webview.css` is listed
 - No `.ts` source files (except `.d.ts`)
 - No `test/` paths
 - No `node_modules/` paths (since `--no-dependencies`)
-**Tests**: The test itself is the validation. Note: the test runs
-`pnpm build` internally as a setup step (with a generous timeout) to
-guarantee build artifacts exist before asserting on `vsce ls` output.
-**QA**: Run `pnpm build` first (prerequisite), then:
-Run `pnpm test` → all tests pass including the new smoke test.
-Run `pnpm test -- --reporter=verbose` → output includes `smoke` project with
-`vsix-content` test name visible.
+  **Tests**: The test itself is the validation. Note: the test runs
+  `pnpm build` internally as a setup step (with a generous timeout) to
+  guarantee build artifacts exist before asserting on `vsce ls` output.
+  **QA**: Run `pnpm build` first (prerequisite), then:
+  Run `pnpm test` → all tests pass including the new smoke test.
+  Run `pnpm test -- --reporter=verbose` → output includes `smoke` project with
+  `vsix-content` test name visible.
 
 ## Dependency Graph
 
@@ -225,11 +241,11 @@ Slices 1 and 2 are the critical path for packaging (Slices 5/6/8).
 
 ## Wave Schedule
 
-| Wave | Slices | Parallel? |
-|------|--------|-----------|
-| 1    | 1, 2, 3, 4 | Yes — all independent |
-| 2    | 5, 6, 7 | Partially — 5 and 7 are independent; 6 depends on 5 |
-| 3    | 8 | Sequential — needs packaging to work |
+| Wave | Slices     | Parallel?                                           |
+| ---- | ---------- | --------------------------------------------------- |
+| 1    | 1, 2, 3, 4 | Yes — all independent                               |
+| 2    | 5, 6, 7    | Partially — 5 and 7 are independent; 6 depends on 5 |
+| 3    | 8          | Sequential — needs packaging to work                |
 
 ## Out of Scope (deferred)
 

--- a/.sisyphus/plans/v1-next-phases.md
+++ b/.sisyphus/plans/v1-next-phases.md
@@ -5,6 +5,7 @@
 > **Quick Summary**: Complete the remaining v1 work for Attractor after M4+M5 ship: finish wiring the live orchestration plumbing (wire-orchestration), close dashboard UX gaps (Run button, control buttons, log viewer, orchestration phase UI), build the React graph surface, implement DOT graph execution, and wire run resume+retry with worktree integration.
 >
 > **Deliverables**:
+>
 > - wire-orchestration committed and merged (T1-T7 + tests)
 > - Plan dashboard: Run Plan CTA wired
 > - Run inspector: log viewer, phase progress UI, cancel/resume/retry buttons
@@ -26,6 +27,7 @@
 `main` is at `42ac2d2` — vitest integration test suite (PR #31).
 
 **What shipped:**
+
 - M0-M5 all merged: contracts, backend spine, dashboard, copilot orchestration, release readiness
 - 503+ tests passing
 - VSIX packaging working
@@ -35,9 +37,11 @@
 - `startOrchestration` in `runtime.ts` — placeholder, does not instantiate OrchestrationLoop
 
 **What's in progress:**
+
 - `wire-orchestration` plan (`.sisyphus/plans/wire-orchestration.md`) — Task 1 code done in extension.ts, not committed
 
 **What's missing for v1:**
+
 1. Real orchestration plumbing (wire-orchestration T1-T7)
 2. Run Plan CTA in PlanSurface
 3. Run inspector: log viewer, orchestration phases, control buttons
@@ -50,35 +54,37 @@
 
 ### Feature Completeness Matrix
 
-| Feature | Status |
-|---------|--------|
-| DOT parsing + validation | ✅ DONE |
-| DOT graph execution (node walker) | ❌ MISSING |
-| Overview dashboard | ✅ DONE |
-| Repository detail surface | ✅ DONE |
-| Plan dashboard — Run CTA | ⚠️ PARTIAL |
-| Run inspector — phases, logs, controls | ⚠️ PARTIAL |
-| Graph rendering (React) | ⚠️ PARTIAL |
-| Event timeline (React) | ⚠️ PARTIAL |
-| Log viewer in RunSurface | ⚠️ PARTIAL |
-| Artifact viewer | ✅ DONE |
-| Orchestration roles 4-phase | ✅ DONE |
-| Model gateway (real Copilot) | ⚙️ IN PROGRESS |
-| Chat commands live | ⚙️ IN PROGRESS |
-| startOrchestration live | ⚙️ IN PROGRESS |
-| Run cancel | ✅ DONE |
-| Run resume | ❌ STUB |
-| Run retry | ❌ STUB |
-| Worktree integration | ❌ MISSING |
+| Feature                                | Status         |
+| -------------------------------------- | -------------- |
+| DOT parsing + validation               | ✅ DONE        |
+| DOT graph execution (node walker)      | ❌ MISSING     |
+| Overview dashboard                     | ✅ DONE        |
+| Repository detail surface              | ✅ DONE        |
+| Plan dashboard — Run CTA               | ⚠️ PARTIAL     |
+| Run inspector — phases, logs, controls | ⚠️ PARTIAL     |
+| Graph rendering (React)                | ⚠️ PARTIAL     |
+| Event timeline (React)                 | ⚠️ PARTIAL     |
+| Log viewer in RunSurface               | ⚠️ PARTIAL     |
+| Artifact viewer                        | ✅ DONE        |
+| Orchestration roles 4-phase            | ✅ DONE        |
+| Model gateway (real Copilot)           | ⚙️ IN PROGRESS |
+| Chat commands live                     | ⚙️ IN PROGRESS |
+| startOrchestration live                | ⚙️ IN PROGRESS |
+| Run cancel                             | ✅ DONE        |
+| Run resume                             | ❌ STUB        |
+| Run retry                              | ❌ STUB        |
+| Worktree integration                   | ❌ MISSING     |
 
 ---
 
 ## Work Objectives
 
 ### Core Objective
+
 Complete the Attractor v1 feature set: live orchestration, full run inspector, graph visualization, and run recovery — so the extension can execute a real plan end-to-end via Copilot.
 
 ### Concrete Deliverables
+
 - `packages/extension/src/extension.ts` — gateway wiring committed
 - `packages/extension/src/runtime.ts` — real startOrchestration
 - `packages/extension/src/chat/attractor-chat-participant.ts` — live /run /plan /status
@@ -91,6 +97,7 @@ Complete the Attractor v1 feature set: live orchestration, full run inspector, g
 - `docs/plans/progress-tracker.md` — updated to reflect current state
 
 ### Definition of Done
+
 - [ ] `pnpm typecheck && pnpm lint && pnpm test --run` passes (503+ tests)
 - [ ] F5 → dashboard → "Run Plan" → Output channel shows orchestration lifecycle
 - [ ] `@attractor /run <planId>` triggers real OrchestrationLoop execution
@@ -99,6 +106,7 @@ Complete the Attractor v1 feature set: live orchestration, full run inspector, g
 - [ ] DOT graph executor dispatches codergen/conditional/wait.human nodes correctly
 
 ### Must Have
+
 - All 503+ existing tests remain green throughout
 - wire-orchestration T1-T7 completed and committed atomically
 - Run Plan CTA in PlanSurface calls postMessage.runPlan(planId)
@@ -109,6 +117,7 @@ Complete the Attractor v1 feature set: live orchestration, full run inspector, g
 - Resume/retry: snapshot-based RunRecord persistence enabling re-entry
 
 ### Must NOT Have (Guardrails)
+
 - Do NOT add `vscode.window.showErrorMessage` — codebase deliberately avoids popups
 - Do NOT modify `orchestration-loop.ts`, `ports.ts`, `copilot-model-gateway.ts` (FROZEN from wire-orchestration plan)
 - Do NOT add new npm packages without explicit justification
@@ -123,11 +132,13 @@ Complete the Attractor v1 feature set: live orchestration, full run inspector, g
 ## Verification Strategy
 
 ### Test Decision
+
 - **Infrastructure exists**: YES (vitest, 503+ tests)
 - **Automated tests**: Tests-after strategy for new components
 - **Framework**: vitest
 
 ### QA Policy
+
 Every task includes agent-executed QA scenarios. Evidence saved to `.sisyphus/evidence/`.
 
 - **Extension changes**: `pnpm test --run` + `pnpm typecheck`
@@ -217,6 +228,7 @@ Wave FINAL (After ALL tasks — 4 parallel reviews):
   - [ ] All wire-orchestration checkboxes marked done
 
   **QA Scenarios**:
+
   ```
   Scenario: Chat /plan returns stored plans
     Tool: Bash (pnpm test --run --reporter=verbose)
@@ -283,6 +295,7 @@ Wave FINAL (After ALL tasks — 4 parallel reviews):
   - [ ] Next Up section points to `.sisyphus/plans/v1-next-phases.md`
 
   **QA Scenarios**:
+
   ```
   Scenario: Progress tracker is readable and accurate
     Tool: Bash (git log --oneline docs/plans/progress-tracker.md)
@@ -347,6 +360,7 @@ Wave FINAL (After ALL tasks — 4 parallel reviews):
   - [ ] `pnpm typecheck && pnpm test --run` passes
 
   **QA Scenarios**:
+
   ```
   Scenario: Run Plan button dispatches runPlan postMessage
     Tool: Bash (pnpm test --run packages/webview)
@@ -423,6 +437,7 @@ Wave FINAL (After ALL tasks — 4 parallel reviews):
   - [ ] `pnpm typecheck && pnpm test --run` passes
 
   **QA Scenarios**:
+
   ```
   Scenario: Orchestration phases panel renders from orchestration.state message
     Tool: Bash (pnpm test --run packages/webview)
@@ -499,6 +514,7 @@ Wave FINAL (After ALL tasks — 4 parallel reviews):
   - [ ] `pnpm typecheck && pnpm test --run` passes
 
   **QA Scenarios**:
+
   ```
   Scenario: GraphSurface renders nodes from graph.update payload
     Tool: Bash (pnpm test --run packages/webview)
@@ -573,6 +589,7 @@ Wave FINAL (After ALL tasks — 4 parallel reviews):
   - [ ] `pnpm typecheck && pnpm test --run` passes
 
   **QA Scenarios**:
+
   ```
   Scenario: Graph executor traverses start→codergen→exit and calls OrchestrationLoop
     Tool: Bash (pnpm test --run packages/extension/test/application/graph-executor.test.ts)
@@ -643,6 +660,7 @@ Wave FINAL (After ALL tasks — 4 parallel reviews):
   - [ ] `pnpm typecheck && pnpm test --run` passes
 
   **QA Scenarios**:
+
   ```
   Scenario: Snapshot saves and reloads correctly
     Tool: Bash (pnpm test --run packages/extension/test/application/run-snapshot.test.ts)
@@ -710,6 +728,7 @@ Wave FINAL (After ALL tasks — 4 parallel reviews):
   - [ ] `pnpm typecheck && pnpm test --run` passes
 
   **QA Scenarios**:
+
   ```
   Scenario: Worktree acquired before orchestration and released after
     Tool: Bash (pnpm test --run packages/extension/test/smoke)
@@ -740,45 +759,46 @@ Wave FINAL (After ALL tasks — 4 parallel reviews):
 > 4 review agents run in PARALLEL. ALL must APPROVE. Present consolidated results to user and get explicit "okay" before completing.
 
 - [ ] F1. **Plan Compliance Audit** — `oracle`
-  Read the plan end-to-end. For each "Must Have": verify implementation exists (read file, run command). For each "Must NOT Have": search codebase for forbidden patterns. Check evidence files exist. Compare deliverables against plan.
-  Output: `Must Have [N/N] | Must NOT Have [N/N] | Tasks [N/N] | VERDICT: APPROVE/REJECT`
+      Read the plan end-to-end. For each "Must Have": verify implementation exists (read file, run command). For each "Must NOT Have": search codebase for forbidden patterns. Check evidence files exist. Compare deliverables against plan.
+      Output: `Must Have [N/N] | Must NOT Have [N/N] | Tasks [N/N] | VERDICT: APPROVE/REJECT`
 
 - [ ] F2. **Code Quality Review** — `unspecified-high`
-  Run `pnpm typecheck && pnpm lint && pnpm test --run`. Review all changed files for: `as any`/`@ts-ignore`, empty catches, console.log in prod, commented-out code, unused imports. Check for AI slop: excessive comments, over-abstraction, generic names.
-  Output: `Build [PASS/FAIL] | Lint [PASS/FAIL] | Tests [N pass/N fail] | Files [N clean/N issues] | VERDICT`
+      Run `pnpm typecheck && pnpm lint && pnpm test --run`. Review all changed files for: `as any`/`@ts-ignore`, empty catches, console.log in prod, commented-out code, unused imports. Check for AI slop: excessive comments, over-abstraction, generic names.
+      Output: `Build [PASS/FAIL] | Lint [PASS/FAIL] | Tests [N pass/N fail] | Files [N clean/N issues] | VERDICT`
 
 - [ ] F3. **Real Manual QA** — `unspecified-high`
-  Start from clean state. Execute EVERY QA scenario from EVERY task. Test integration: Run Plan button → bridge → startOrchestration → OrchestrationLoop (with mock model). Test graph executor end-to-end with minimal DOT graph. Save to `.sisyphus/evidence/final-qa/`.
-  Output: `Scenarios [N/N pass] | Integration [N/N] | VERDICT`
+      Start from clean state. Execute EVERY QA scenario from EVERY task. Test integration: Run Plan button → bridge → startOrchestration → OrchestrationLoop (with mock model). Test graph executor end-to-end with minimal DOT graph. Save to `.sisyphus/evidence/final-qa/`.
+      Output: `Scenarios [N/N pass] | Integration [N/N] | VERDICT`
 
 - [ ] F4. **Scope Fidelity Check** — `deep`
-  For each task: read "What to do", read actual diff. Verify 1:1 — everything in spec was built, nothing beyond spec was built. Check "Must NOT do" compliance. Flag `infrastructure/` duplication if any appears.
-  Output: `Tasks [N/N compliant] | Contamination [CLEAN/N issues] | VERDICT`
+      For each task: read "What to do", read actual diff. Verify 1:1 — everything in spec was built, nothing beyond spec was built. Check "Must NOT do" compliance. Flag `infrastructure/` duplication if any appears.
+      Output: `Tasks [N/N compliant] | Contamination [CLEAN/N issues] | VERDICT`
 
 ---
 
 ## Commit Strategy
 
-| Commit | Message | Files |
-|--------|---------|-------|
-| 1 | `feat(extension): wire CopilotModelGateway at activation` | `src/extension.ts`, `test/smoke/gateway-wiring.test.ts` |
-| 2 | `refactor(chat): accept ChatHandlerDependencies in buildChatHandler` | `src/chat/attractor-chat-participant.ts`, tests |
-| 3 | `feat(runtime): implement startOrchestration with OrchestrationLoop` | `src/runtime.ts`, tests |
-| 4 | `feat(chat): wire /plan, /run, /status commands to real services` | `src/chat/attractor-chat-participant.ts`, tests |
-| 5 | `feat(runtime): add structured orchestration lifecycle logging` | `src/runtime.ts`, tests |
-| 6 | `docs: update progress tracker to current state post-M5` | `docs/plans/progress-tracker.md` |
-| 7 | `feat(webview): add Run Plan CTA to PlanSurface and control buttons to RunSurface` | webview sources + tests |
-| 8 | `feat(webview): add orchestration phases panel and log viewer to RunSurface` | webview sources + tests |
-| 9 | `feat(webview): add React GraphSurface and TimelinePanel components` | webview sources + tests |
-| 10 | `feat(extension): add DOT graph executor for node-based plan traversal` | `src/application/graph-executor.ts`, tests |
-| 11 | `feat(extension): implement run snapshot persistence for resume and retry` | `src/application/run-snapshot.ts`, `src/dashboard/bridge.ts`, tests |
-| 12 | `feat(extension): wire GitWorktreeManager acquire/release into startOrchestration` | `src/runtime.ts`, tests |
+| Commit | Message                                                                            | Files                                                               |
+| ------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| 1      | `feat(extension): wire CopilotModelGateway at activation`                          | `src/extension.ts`, `test/smoke/gateway-wiring.test.ts`             |
+| 2      | `refactor(chat): accept ChatHandlerDependencies in buildChatHandler`               | `src/chat/attractor-chat-participant.ts`, tests                     |
+| 3      | `feat(runtime): implement startOrchestration with OrchestrationLoop`               | `src/runtime.ts`, tests                                             |
+| 4      | `feat(chat): wire /plan, /run, /status commands to real services`                  | `src/chat/attractor-chat-participant.ts`, tests                     |
+| 5      | `feat(runtime): add structured orchestration lifecycle logging`                    | `src/runtime.ts`, tests                                             |
+| 6      | `docs: update progress tracker to current state post-M5`                           | `docs/plans/progress-tracker.md`                                    |
+| 7      | `feat(webview): add Run Plan CTA to PlanSurface and control buttons to RunSurface` | webview sources + tests                                             |
+| 8      | `feat(webview): add orchestration phases panel and log viewer to RunSurface`       | webview sources + tests                                             |
+| 9      | `feat(webview): add React GraphSurface and TimelinePanel components`               | webview sources + tests                                             |
+| 10     | `feat(extension): add DOT graph executor for node-based plan traversal`            | `src/application/graph-executor.ts`, tests                          |
+| 11     | `feat(extension): implement run snapshot persistence for resume and retry`         | `src/application/run-snapshot.ts`, `src/dashboard/bridge.ts`, tests |
+| 12     | `feat(extension): wire GitWorktreeManager acquire/release into startOrchestration` | `src/runtime.ts`, tests                                             |
 
 ---
 
 ## Success Criteria
 
 ### Verification Commands
+
 ```bash
 pnpm typecheck     # Expected: exit 0, zero errors
 pnpm lint          # Expected: exit 0, zero violations
@@ -786,6 +806,7 @@ pnpm test --run    # Expected: all 503+ tests pass
 ```
 
 ### Final Checklist
+
 - [ ] All "Must Have" present
 - [ ] All "Must NOT Have" absent (frozen files untouched, no `infrastructure/` duplicate)
 - [ ] All 503+ tests pass

--- a/packages/webview/esbuild.config.mjs
+++ b/packages/webview/esbuild.config.mjs
@@ -20,7 +20,7 @@
 
 import esbuild from "esbuild";
 import { execFileSync, spawn } from "node:child_process";
-import { copyFileSync, mkdirSync } from "node:fs";
+import { copyFileSync, mkdirSync, watchFile } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -89,6 +89,15 @@ if (watch) {
     plugins: [copyPreviewPlugin]
   });
   await jsCtx.watch();
+
+  // Watch ui-preview.html directly so edits are propagated without needing a
+  // JS rebuild (it is not in esbuild's dependency graph).
+  const previewSrc = path.join(__dirname, "ui-preview.html");
+  const previewDst = path.join(distDir, "ui-preview.html");
+  watchFile(previewSrc, { interval: 500 }, () => {
+    copyFileSync(previewSrc, previewDst);
+    console.log("[attractor/webview] ui-preview.html updated in dist/");
+  });
 
   // CSS: postcss --watch
   const cssProc = spawn(

--- a/packages/webview/esbuild.config.mjs
+++ b/packages/webview/esbuild.config.mjs
@@ -20,7 +20,7 @@
 
 import esbuild from "esbuild";
 import { execFileSync, spawn } from "node:child_process";
-import { mkdirSync } from "node:fs";
+import { copyFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -34,7 +34,8 @@ const production =
     ? process.env.NODE_ENV === "production"
     : !watch;
 
-const outDir = path.join(__dirname, "dist", "bundle");
+const distDir = path.join(__dirname, "dist");
+const outDir = path.join(distDir, "bundle");
 const cssIn = path.join(__dirname, "src", "styles", "index.css");
 const cssOut = path.join(outDir, "webview.css");
 
@@ -45,6 +46,12 @@ const postcssBin =
 
 // Ensure output directory exists
 mkdirSync(outDir, { recursive: true });
+
+// Copy preview harness to dist so it can be served alongside the bundle
+copyFileSync(
+  path.join(__dirname, "ui-preview.html"),
+  path.join(distDir, "ui-preview.html")
+);
 
 /** @type {import('esbuild').BuildOptions} */
 const jsOptions = {

--- a/packages/webview/esbuild.config.mjs
+++ b/packages/webview/esbuild.config.mjs
@@ -66,9 +66,28 @@ const jsOptions = {
   minify: production
 };
 
+/** esbuild plugin that re-copies ui-preview.html into dist/ after every build.
+ *  In watch mode, copyFileSync runs only once at startup; this plugin ensures
+ *  edits to the harness are picked up on subsequent incremental rebuilds.
+ */
+const copyPreviewPlugin = {
+  name: "copy-preview-harness",
+  setup(build) {
+    build.onEnd(() => {
+      copyFileSync(
+        path.join(__dirname, "ui-preview.html"),
+        path.join(distDir, "ui-preview.html")
+      );
+    });
+  }
+};
+
 if (watch) {
-  // JS: esbuild watch
-  const jsCtx = await esbuild.context(jsOptions);
+  // JS: esbuild watch (with preview-harness copy on each rebuild)
+  const jsCtx = await esbuild.context({
+    ...jsOptions,
+    plugins: [copyPreviewPlugin]
+  });
   await jsCtx.watch();
 
   // CSS: postcss --watch

--- a/packages/webview/ui-preview.html
+++ b/packages/webview/ui-preview.html
@@ -129,10 +129,12 @@
   </head>
   <body>
     <div id="surface-tabs">
-      <button class="active" onclick="showSurface('overview')">Overview</button>
-      <button onclick="showSurface('repository')">Repository</button>
-      <button onclick="showSurface('plan')">Plan</button>
-      <button onclick="showSurface('run')">Run Inspector</button>
+      <button class="active" onclick="showSurface('overview', event)">
+        Overview
+      </button>
+      <button onclick="showSurface('repository', event)">Repository</button>
+      <button onclick="showSurface('plan', event)">Plan</button>
+      <button onclick="showSurface('run', event)">Run Inspector</button>
       <button id="theme-toggle" onclick="toggleTheme()">Light Theme</button>
     </div>
 
@@ -416,7 +418,7 @@
         }
       }
 
-      function showSurface(surface) {
+      function showSurface(surface, evt) {
         currentSurface = surface;
 
         // Update tab buttons
@@ -425,7 +427,7 @@
           .forEach((btn) => {
             btn.classList.remove("active");
           });
-        event.target.classList.add("active");
+        evt.target.classList.add("active");
 
         // Send navigate message then state
         window.dispatchEvent(

--- a/packages/webview/ui-preview.html
+++ b/packages/webview/ui-preview.html
@@ -1,338 +1,568 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Attractor UI Preview</title>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Attractor UI Preview</title>
 
-  <!-- Mock VS Code CSS variables (Dark+ theme) -->
-  <style>
-    :root {
-      --vscode-editor-background: #1e1e1e;
-      --vscode-editor-foreground: #d4d4d4;
-      --vscode-sideBar-background: #252526;
-      --vscode-sideBar-foreground: #cccccc;
-      --vscode-panel-background: #1e1e1e;
-      --vscode-panel-border: #454545;
-      --vscode-button-background: #0e639c;
-      --vscode-button-foreground: #ffffff;
-      --vscode-button-hoverBackground: #1177bb;
-      --vscode-button-secondaryBackground: #3a3d41;
-      --vscode-button-secondaryForeground: #cccccc;
-      --vscode-button-secondaryHoverBackground: #44474b;
-      --vscode-input-background: #3c3c3c;
-      --vscode-input-foreground: #cccccc;
-      --vscode-input-border: #3c3c3c;
-      --vscode-focusBorder: #007fd4;
-      --vscode-errorForeground: #f48771;
-      --vscode-editorWarning-foreground: #cca700;
-      --vscode-editorInfo-foreground: #75beff;
-      --vscode-testing-iconPassed: #73c991;
-      --vscode-testing-iconFailed: #f48771;
-      --vscode-badge-background: #4d4d4d;
-      --vscode-badge-foreground: #ffffff;
-      --vscode-descriptionForeground: #8b949e;
-      --vscode-progressBar-background: #0e70c0;
-      --vscode-disabledForeground: #6d6d6d;
-      --vscode-inputValidation-errorBorder: #be1100;
-      --vscode-list-errorForeground: #f48771;
-      --vscode-list-hoverBackground: #2a2d2e;
-      --vscode-list-activeSelectionBackground: #094771;
-      --vscode-list-activeSelectionForeground: #ffffff;
-      --vscode-list-inactiveSelectionBackground: #37373d;
-      --vscode-textSeparator-foreground: #424242;
-      --vscode-tree-indentGuidesStroke: #585858;
-      --vscode-debugIcon-pauseForeground: #f48771;
-      --vscode-contrastBorder: transparent;
-      --vscode-contrastActiveBorder: transparent;
-      --vscode-notifications-background: #252526;
-      --vscode-charts-red: #f14c4c;
-      --vscode-charts-blue: #3794ff;
-      --vscode-charts-orange: #d18616;
-      --vscode-charts-green: #89d185;
-      --vscode-terminal-background: #1e1e1e;
-      --vscode-terminal-foreground: #cccccc;
-      --vscode-settings-headerForeground: #e7e7e7;
-      --vscode-textLink-foreground: #3794ff;
-      --vscode-textLink-activeForeground: #3794ff;
-      --vscode-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      --vscode-font-size: 13px;
-      --vscode-editor-font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
-    }
-
-    html, body {
-      margin: 0;
-      padding: 0;
-      height: 100%;
-      overflow: hidden;
-    }
-
-    #surface-tabs {
-      display: flex;
-      background: #252526;
-      border-bottom: 1px solid #454545;
-      padding: 0 8px;
-      gap: 4px;
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      z-index: 100;
-    }
-
-    #surface-tabs button {
-      padding: 6px 12px;
-      background: none;
-      border: none;
-      color: #ccc;
-      cursor: pointer;
-      font-size: 12px;
-      font-family: var(--vscode-font-family);
-      border-bottom: 2px solid transparent;
-      margin-bottom: -1px;
-    }
-
-    #surface-tabs button.active {
-      color: #fff;
-      border-bottom-color: #007acc;
-    }
-
-    #surface-tabs button:hover {
-      color: #fff;
-    }
-
-    #theme-toggle {
-      margin-left: auto;
-      padding: 4px 10px;
-      background: #3a3d41;
-      border: 1px solid #555;
-      color: #ccc;
-      cursor: pointer;
-      font-size: 11px;
-      border-radius: 3px;
-      align-self: center;
-    }
-
-    #app {
-      position: fixed;
-      top: 33px;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      overflow: hidden;
-    }
-  </style>
-  <link rel="stylesheet" href="bundle/webview.css" />
-</head>
-<body>
-
-  <div id="surface-tabs">
-    <button class="active" onclick="showSurface('overview')">Overview</button>
-    <button onclick="showSurface('repository')">Repository</button>
-    <button onclick="showSurface('plan')">Plan</button>
-    <button onclick="showSurface('run')">Run Inspector</button>
-    <button id="theme-toggle" onclick="toggleTheme()">Light Theme</button>
-  </div>
-
-  <div id="root"></div>
-
-  <script src="bundle/webview.js"></script>
-  <script>
-    // ── Mock data ──────────────────────────────────────────────────────────────
-
-    const OVERVIEW_STATE = {
-      stats: { totalRepos: 3, totalPlans: 7, activeRuns: 2, pausedRuns: 1, failedRuns24h: 1 },
-      repositories: [
-        { id: "repo-1", name: "my-app", defaultBranch: "main" },
-        { id: "repo-2", name: "infra-config", defaultBranch: "trunk" },
-        { id: "repo-3", name: "api-gateway", defaultBranch: "main" }
-      ],
-      activeRuns: [
-        { id: "run-abc123", planId: "plan-001", status: "running" },
-        { id: "run-def456", planId: "plan-002", status: "queued" }
-      ],
-      recentFailures: [
-        { id: "run-xyz789", planId: "plan-003", status: "failed" }
-      ],
-      error: null
-    };
-
-    const REPOSITORY_STATE = {
-      repository: {
-        id: "repo-1",
-        name: "my-app",
-        defaultBranch: "main",
-        labels: ["typescript", "frontend"]
-      },
-      plans: [
-        { id: "plan-001", title: "Feature: Add OAuth login", status: "running", updatedAt: "2026-03-29T12:00:00Z" },
-        { id: "plan-002", title: "Refactor: API client", status: "ready", updatedAt: "2026-03-28T09:00:00Z" },
-        { id: "plan-003", title: "Fix: Memory leak in cache", status: "completed", updatedAt: "2026-03-27T16:30:00Z" }
-      ],
-      runs: [
-        { id: "run-abc123", status: "running", attempt: 1, createdAt: "2026-03-29T11:00:00Z" },
-        { id: "run-old001", status: "completed", attempt: 2, createdAt: "2026-03-28T10:00:00Z" },
-        { id: "run-xyz789", status: "failed", attempt: 1, createdAt: "2026-03-27T16:00:00Z" }
-      ],
-      activity: [
-        { id: "evt-1", kind: "created", entityType: "plan", entityId: "plan-001", timestamp: "2026-03-29T11:55:00Z" },
-        { id: "evt-2", kind: "status.changed", entityType: "run", entityId: "run-abc123", timestamp: "2026-03-29T11:00:00Z" },
-        { id: "evt-3", kind: "artifact.created", entityType: "artifact", entityId: "art-001", timestamp: "2026-03-29T11:30:00Z" },
-        { id: "evt-4", kind: "validation.failed", entityType: "plan", entityId: "plan-003", timestamp: "2026-03-27T15:45:00Z" }
-      ]
-    };
-
-    const PLAN_STATE = {
-      plan: {
-        id: "plan-001",
-        title: "Feature: Add OAuth login",
-        goal: "Implement GitHub OAuth integration for single-sign-on, including callback handler, session management, and UI updates.",
-        status: "running",
-        graphSource: ".attractor/plans/oauth-login.dot",
-        createdAt: "2026-03-25T09:00:00Z",
-        updatedAt: "2026-03-29T12:00:00Z",
-        repositories: [
-          { repositoryId: "repo-1", role: "primary", access: "write", mountAlias: "app", ref: "feature/oauth" }
-        ]
-      },
-      milestones: [
-        { id: "m-1", title: "Research & Planning", order: 1, status: "completed", acceptanceCriteria: ["Documented OAuth flow", "Selected library"] },
-        { id: "m-2", title: "Backend Auth Endpoint", order: 2, status: "running", acceptanceCriteria: ["POST /auth/github", "Session created on success"] },
-        { id: "m-3", title: "Frontend Login UI", order: 3, status: "pending", acceptanceCriteria: ["Button renders", "Redirect works"] },
-        { id: "m-4", title: "E2E Tests", order: 4, status: "pending", acceptanceCriteria: ["Test login flow", "Test logout flow"] }
-      ],
-      history: [
-        { id: "run-old001", status: "failed", attempt: 1, createdAt: "2026-03-28T10:00:00Z" },
-        { id: "run-abc123", status: "running", attempt: 2, createdAt: "2026-03-29T11:00:00Z" }
-      ],
-      validationEvents: [
-        {
-          id: "evt-v1", kind: "status.changed", entityType: "plan", entityId: "plan-001",
-          entityKind: "plan", aggregateId: "plan-001", correlationId: "corr-1",
-          timestamp: "2026-03-29T11:00:00Z", payload: { reason: "Started run attempt 2" }
-        }
-      ]
-    };
-
-    const RUN_STATE = {
-      run: {
-        id: "run-abc123",
-        status: "running",
-        attempt: 2,
-        planId: "plan-001"
-      },
-      plan: {
-        id: "plan-001",
-        title: "Feature: Add OAuth login"
-      },
-      milestoneRuns: [
-        { id: "mr-1", nodeId: "research", status: "succeeded", startedAt: "2026-03-29T11:00:00Z", endedAt: "2026-03-29T11:15:00Z" },
-        { id: "mr-2", nodeId: "backend-auth", status: "running", startedAt: "2026-03-29T11:15:00Z" },
-        { id: "mr-3", nodeId: "frontend-ui", status: "queued", startedAt: "2026-03-29T11:00:00Z" },
-        { id: "mr-4", nodeId: "e2e-tests", status: "queued", startedAt: "2026-03-29T11:00:00Z" }
-      ],
-      artifacts: [
-        { id: "art-1", title: "oauth-research.md", type: "document", createdAt: "2026-03-29T11:14:00Z" },
-        { id: "art-2", title: "auth-endpoint.ts", type: "task-pack", createdAt: "2026-03-29T11:20:00Z" }
-      ],
-      currentHandoff: {
-        fromRole: "planner",
-        toRole: "implementer",
-        task: "Implement the POST /auth/github endpoint with session creation",
-        reason: "Planning phase complete. Implementation ready to begin."
+    <!-- Mock VS Code CSS variables (Dark+ theme) -->
+    <style>
+      :root {
+        --vscode-editor-background: #1e1e1e;
+        --vscode-editor-foreground: #d4d4d4;
+        --vscode-sideBar-background: #252526;
+        --vscode-sideBar-foreground: #cccccc;
+        --vscode-panel-background: #1e1e1e;
+        --vscode-panel-border: #454545;
+        --vscode-button-background: #0e639c;
+        --vscode-button-foreground: #ffffff;
+        --vscode-button-hoverBackground: #1177bb;
+        --vscode-button-secondaryBackground: #3a3d41;
+        --vscode-button-secondaryForeground: #cccccc;
+        --vscode-button-secondaryHoverBackground: #44474b;
+        --vscode-input-background: #3c3c3c;
+        --vscode-input-foreground: #cccccc;
+        --vscode-input-border: #3c3c3c;
+        --vscode-focusBorder: #007fd4;
+        --vscode-errorForeground: #f48771;
+        --vscode-editorWarning-foreground: #cca700;
+        --vscode-editorInfo-foreground: #75beff;
+        --vscode-testing-iconPassed: #73c991;
+        --vscode-testing-iconFailed: #f48771;
+        --vscode-badge-background: #4d4d4d;
+        --vscode-badge-foreground: #ffffff;
+        --vscode-descriptionForeground: #8b949e;
+        --vscode-progressBar-background: #0e70c0;
+        --vscode-disabledForeground: #6d6d6d;
+        --vscode-inputValidation-errorBorder: #be1100;
+        --vscode-list-errorForeground: #f48771;
+        --vscode-list-hoverBackground: #2a2d2e;
+        --vscode-list-activeSelectionBackground: #094771;
+        --vscode-list-activeSelectionForeground: #ffffff;
+        --vscode-list-inactiveSelectionBackground: #37373d;
+        --vscode-textSeparator-foreground: #424242;
+        --vscode-tree-indentGuidesStroke: #585858;
+        --vscode-debugIcon-pauseForeground: #f48771;
+        --vscode-contrastBorder: transparent;
+        --vscode-contrastActiveBorder: transparent;
+        --vscode-notifications-background: #252526;
+        --vscode-charts-red: #f14c4c;
+        --vscode-charts-blue: #3794ff;
+        --vscode-charts-orange: #d18616;
+        --vscode-charts-green: #89d185;
+        --vscode-terminal-background: #1e1e1e;
+        --vscode-terminal-foreground: #cccccc;
+        --vscode-settings-headerForeground: #e7e7e7;
+        --vscode-textLink-foreground: #3794ff;
+        --vscode-textLink-activeForeground: #3794ff;
+        --vscode-font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        --vscode-font-size: 13px;
+        --vscode-editor-font-family:
+          "Menlo", "Monaco", "Courier New", monospace;
       }
-    };
 
-    // ── VS Code acquireVsCodeApi mock ────────────────────────────────────────
-    window.acquireVsCodeApi = function() {
-      return {
-        postMessage: function(msg) {
-          console.log('[mock vscode] postMessage:', msg);
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+      }
+
+      #surface-tabs {
+        display: flex;
+        background: #252526;
+        border-bottom: 1px solid #454545;
+        padding: 0 8px;
+        gap: 4px;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 100;
+      }
+
+      #surface-tabs button {
+        padding: 6px 12px;
+        background: none;
+        border: none;
+        color: var(--preview-tab-color, #ccc);
+        cursor: pointer;
+        font-size: 12px;
+        font-family: var(--vscode-font-family);
+        border-bottom: 2px solid transparent;
+        margin-bottom: -1px;
+      }
+
+      #surface-tabs button.active {
+        color: var(--preview-tab-active-color, #fff);
+        border-bottom-color: #007acc;
+      }
+
+      #surface-tabs button:hover {
+        color: var(--preview-tab-active-color, #fff);
+      }
+
+      #theme-toggle {
+        margin-left: auto;
+        padding: 4px 10px;
+        background: #3a3d41;
+        border: 1px solid #555;
+        color: #ccc;
+        cursor: pointer;
+        font-size: 11px;
+        border-radius: 3px;
+        align-self: center;
+      }
+
+      #root {
+        position: fixed;
+        top: 33px;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        overflow: hidden;
+      }
+    </style>
+    <link rel="stylesheet" href="bundle/webview.css" />
+  </head>
+  <body>
+    <div id="surface-tabs">
+      <button class="active" onclick="showSurface('overview')">Overview</button>
+      <button onclick="showSurface('repository')">Repository</button>
+      <button onclick="showSurface('plan')">Plan</button>
+      <button onclick="showSurface('run')">Run Inspector</button>
+      <button id="theme-toggle" onclick="toggleTheme()">Light Theme</button>
+    </div>
+
+    <div id="root"></div>
+
+    <script src="bundle/webview.js"></script>
+    <script>
+      // ── Mock data ──────────────────────────────────────────────────────────────
+
+      const OVERVIEW_STATE = {
+        stats: {
+          totalRepos: 3,
+          totalPlans: 7,
+          activeRuns: 2,
+          pausedRuns: 1,
+          failedRuns24h: 1
         },
-        getState: function() { return null; },
-        setState: function(state) { console.log('[mock vscode] setState:', state); }
+        repositories: [
+          { id: "repo-1", name: "my-app", defaultBranch: "main" },
+          { id: "repo-2", name: "infra-config", defaultBranch: "trunk" },
+          { id: "repo-3", name: "api-gateway", defaultBranch: "main" }
+        ],
+        activeRuns: [
+          { id: "run-abc123", planId: "plan-001", status: "running" },
+          { id: "run-def456", planId: "plan-002", status: "queued" }
+        ],
+        recentFailures: [
+          { id: "run-xyz789", planId: "plan-003", status: "failed" }
+        ],
+        error: null
       };
-    };
 
-    // ── Surface switching ─────────────────────────────────────────────────────
-    let currentSurface = 'overview';
-
-    function sendState(surface) {
-      const msgMap = {
-        overview: { type: 'overview.state', payload: OVERVIEW_STATE },
-        repository: { type: 'repository.state', payload: REPOSITORY_STATE },
-        plan: { type: 'plan.state', payload: PLAN_STATE },
-        run: { type: 'run.state', payload: RUN_STATE }
+      const REPOSITORY_STATE = {
+        repository: {
+          id: "repo-1",
+          name: "my-app",
+          defaultBranch: "main",
+          labels: ["typescript", "frontend"]
+        },
+        plans: [
+          {
+            id: "plan-001",
+            title: "Feature: Add OAuth login",
+            status: "running",
+            updatedAt: "2026-03-29T12:00:00Z"
+          },
+          {
+            id: "plan-002",
+            title: "Refactor: API client",
+            status: "ready",
+            updatedAt: "2026-03-28T09:00:00Z"
+          },
+          {
+            id: "plan-003",
+            title: "Fix: Memory leak in cache",
+            status: "completed",
+            updatedAt: "2026-03-27T16:30:00Z"
+          }
+        ],
+        runs: [
+          {
+            id: "run-abc123",
+            status: "running",
+            attempt: 1,
+            createdAt: "2026-03-29T11:00:00Z"
+          },
+          {
+            id: "run-old001",
+            status: "completed",
+            attempt: 2,
+            createdAt: "2026-03-28T10:00:00Z"
+          },
+          {
+            id: "run-xyz789",
+            status: "failed",
+            attempt: 1,
+            createdAt: "2026-03-27T16:00:00Z"
+          }
+        ],
+        activity: [
+          {
+            id: "evt-1",
+            kind: "created",
+            entityType: "plan",
+            entityId: "plan-001",
+            timestamp: "2026-03-29T11:55:00Z"
+          },
+          {
+            id: "evt-2",
+            kind: "status.changed",
+            entityType: "run",
+            entityId: "run-abc123",
+            timestamp: "2026-03-29T11:00:00Z"
+          },
+          {
+            id: "evt-3",
+            kind: "artifact.created",
+            entityType: "artifact",
+            entityId: "art-001",
+            timestamp: "2026-03-29T11:30:00Z"
+          },
+          {
+            id: "evt-4",
+            kind: "validation.failed",
+            entityType: "plan",
+            entityId: "plan-003",
+            timestamp: "2026-03-27T15:45:00Z"
+          }
+        ]
       };
-      const msg = msgMap[surface];
-      if (msg) {
-        window.dispatchEvent(new MessageEvent('message', { data: msg }));
+
+      const PLAN_STATE = {
+        plan: {
+          id: "plan-001",
+          title: "Feature: Add OAuth login",
+          goal: "Implement GitHub OAuth integration for single-sign-on, including callback handler, session management, and UI updates.",
+          status: "running",
+          graphSource: ".attractor/plans/oauth-login.dot",
+          createdAt: "2026-03-25T09:00:00Z",
+          updatedAt: "2026-03-29T12:00:00Z",
+          repositories: [
+            {
+              repositoryId: "repo-1",
+              role: "primary",
+              access: "write",
+              mountAlias: "app",
+              ref: "feature/oauth"
+            }
+          ]
+        },
+        milestones: [
+          {
+            id: "m-1",
+            title: "Research & Planning",
+            order: 1,
+            status: "completed",
+            acceptanceCriteria: ["Documented OAuth flow", "Selected library"]
+          },
+          {
+            id: "m-2",
+            title: "Backend Auth Endpoint",
+            order: 2,
+            status: "running",
+            acceptanceCriteria: [
+              "POST /auth/github",
+              "Session created on success"
+            ]
+          },
+          {
+            id: "m-3",
+            title: "Frontend Login UI",
+            order: 3,
+            status: "pending",
+            acceptanceCriteria: ["Button renders", "Redirect works"]
+          },
+          {
+            id: "m-4",
+            title: "E2E Tests",
+            order: 4,
+            status: "pending",
+            acceptanceCriteria: ["Test login flow", "Test logout flow"]
+          }
+        ],
+        history: [
+          {
+            id: "run-old001",
+            status: "failed",
+            attempt: 1,
+            createdAt: "2026-03-28T10:00:00Z"
+          },
+          {
+            id: "run-abc123",
+            status: "running",
+            attempt: 2,
+            createdAt: "2026-03-29T11:00:00Z"
+          }
+        ],
+        validationEvents: [
+          {
+            id: "evt-v1",
+            kind: "status.changed",
+            entityType: "plan",
+            entityId: "plan-001",
+            entityKind: "plan",
+            aggregateId: "plan-001",
+            correlationId: "corr-1",
+            timestamp: "2026-03-29T11:00:00Z",
+            payload: { reason: "Started run attempt 2" }
+          }
+        ]
+      };
+
+      const RUN_STATE = {
+        run: {
+          id: "run-abc123",
+          status: "running",
+          attempt: 2,
+          planId: "plan-001"
+        },
+        plan: {
+          id: "plan-001",
+          title: "Feature: Add OAuth login"
+        },
+        milestoneRuns: [
+          {
+            id: "mr-1",
+            nodeId: "research",
+            status: "succeeded",
+            startedAt: "2026-03-29T11:00:00Z",
+            endedAt: "2026-03-29T11:15:00Z"
+          },
+          {
+            id: "mr-2",
+            nodeId: "backend-auth",
+            status: "running",
+            startedAt: "2026-03-29T11:15:00Z"
+          },
+          {
+            id: "mr-3",
+            nodeId: "frontend-ui",
+            status: "queued",
+            startedAt: "2026-03-29T11:00:00Z"
+          },
+          {
+            id: "mr-4",
+            nodeId: "e2e-tests",
+            status: "queued",
+            startedAt: "2026-03-29T11:00:00Z"
+          }
+        ],
+        artifacts: [
+          {
+            id: "art-1",
+            title: "oauth-research.md",
+            type: "document",
+            createdAt: "2026-03-29T11:14:00Z"
+          },
+          {
+            id: "art-2",
+            title: "auth-endpoint.ts",
+            type: "task-pack",
+            createdAt: "2026-03-29T11:20:00Z"
+          }
+        ],
+        currentHandoff: {
+          fromRole: "planner",
+          toRole: "implementer",
+          task: "Implement the POST /auth/github endpoint with session creation",
+          reason: "Planning phase complete. Implementation ready to begin."
+        }
+      };
+
+      // ── VS Code acquireVsCodeApi mock ────────────────────────────────────────
+      window.acquireVsCodeApi = function () {
+        return {
+          postMessage: function (msg) {
+            console.log("[mock vscode] postMessage:", msg);
+          },
+          getState: function () {
+            return null;
+          },
+          setState: function (state) {
+            console.log("[mock vscode] setState:", state);
+          }
+        };
+      };
+
+      // ── Surface switching ─────────────────────────────────────────────────────
+      let currentSurface = "overview";
+
+      function sendState(surface) {
+        const msgMap = {
+          overview: { type: "overview.state", payload: OVERVIEW_STATE },
+          repository: { type: "repository.state", payload: REPOSITORY_STATE },
+          plan: { type: "plan.state", payload: PLAN_STATE },
+          run: { type: "run.state", payload: RUN_STATE }
+        };
+        const msg = msgMap[surface];
+        if (msg) {
+          window.dispatchEvent(new MessageEvent("message", { data: msg }));
+        }
       }
-    }
 
-    function showSurface(surface) {
-      currentSurface = surface;
+      function showSurface(surface) {
+        currentSurface = surface;
 
-      // Update tab buttons
-      document.querySelectorAll('#surface-tabs button:not(#theme-toggle)').forEach(btn => {
-        btn.classList.remove('active');
+        // Update tab buttons
+        document
+          .querySelectorAll("#surface-tabs button:not(#theme-toggle)")
+          .forEach((btn) => {
+            btn.classList.remove("active");
+          });
+        event.target.classList.add("active");
+
+        // Send navigate message then state
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            data: { type: "navigate", surface: surface }
+          })
+        );
+
+        // Small delay to let navigation settle
+        setTimeout(() => sendState(surface), 50);
+      }
+
+      // ── Light theme support ──────────────────────────────────────────────────
+      let isLight = false;
+      function toggleTheme() {
+        isLight = !isLight;
+        document.getElementById("theme-toggle").textContent = isLight
+          ? "Dark Theme"
+          : "Light Theme";
+
+        if (isLight) {
+          document.documentElement.style.setProperty(
+            "--vscode-editor-background",
+            "#ffffff"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-editor-foreground",
+            "#1e1e1e"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-sideBar-background",
+            "#f3f3f3"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-panel-background",
+            "#ffffff"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-panel-border",
+            "#e0e0e0"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-list-hoverBackground",
+            "#e8e8e8"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-list-inactiveSelectionBackground",
+            "#e4e6f1"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-descriptionForeground",
+            "#717171"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-badge-background",
+            "#c4c4c4"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-badge-foreground",
+            "#333333"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-settings-headerForeground",
+            "#1e1e1e"
+          );
+          document.getElementById("surface-tabs").style.background = "#f3f3f3";
+          document.getElementById("surface-tabs").style.borderBottomColor =
+            "#e0e0e0";
+          document
+            .getElementById("surface-tabs")
+            .style.setProperty("--preview-tab-color", "#555");
+          document
+            .getElementById("surface-tabs")
+            .style.setProperty("--preview-tab-active-color", "#1e1e1e");
+        } else {
+          document.documentElement.style.setProperty(
+            "--vscode-editor-background",
+            "#1e1e1e"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-editor-foreground",
+            "#d4d4d4"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-sideBar-background",
+            "#252526"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-panel-background",
+            "#1e1e1e"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-panel-border",
+            "#454545"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-list-hoverBackground",
+            "#2a2d2e"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-list-inactiveSelectionBackground",
+            "#37373d"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-descriptionForeground",
+            "#8b949e"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-badge-background",
+            "#4d4d4d"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-badge-foreground",
+            "#ffffff"
+          );
+          document.documentElement.style.setProperty(
+            "--vscode-settings-headerForeground",
+            "#e7e7e7"
+          );
+          document.getElementById("surface-tabs").style.background = "#252526";
+          document.getElementById("surface-tabs").style.borderBottomColor =
+            "#454545";
+          document
+            .getElementById("surface-tabs")
+            .style.setProperty("--preview-tab-color", "#ccc");
+          document
+            .getElementById("surface-tabs")
+            .style.setProperty("--preview-tab-active-color", "#fff");
+        }
+      }
+
+      // ── Boot: send initial state after webview mounts ────────────────────────
+      window.addEventListener("load", () => {
+        setTimeout(() => {
+          sendState("overview");
+        }, 200);
       });
-      event.target.classList.add('active');
-
-      // Send navigate message then state
-      window.dispatchEvent(new MessageEvent('message', {
-        data: { type: 'navigate', surface: surface }
-      }));
-
-      // Small delay to let navigation settle
-      setTimeout(() => sendState(surface), 50);
-    }
-
-    // ── Light theme support ──────────────────────────────────────────────────
-    let isLight = false;
-    function toggleTheme() {
-      isLight = !isLight;
-      document.getElementById('theme-toggle').textContent = isLight ? 'Dark Theme' : 'Light Theme';
-
-      if (isLight) {
-        document.documentElement.style.setProperty('--vscode-editor-background', '#ffffff');
-        document.documentElement.style.setProperty('--vscode-editor-foreground', '#1e1e1e');
-        document.documentElement.style.setProperty('--vscode-sideBar-background', '#f3f3f3');
-        document.documentElement.style.setProperty('--vscode-panel-background', '#ffffff');
-        document.documentElement.style.setProperty('--vscode-panel-border', '#e0e0e0');
-        document.documentElement.style.setProperty('--vscode-list-hoverBackground', '#e8e8e8');
-        document.documentElement.style.setProperty('--vscode-list-inactiveSelectionBackground', '#e4e6f1');
-        document.documentElement.style.setProperty('--vscode-descriptionForeground', '#717171');
-        document.documentElement.style.setProperty('--vscode-badge-background', '#c4c4c4');
-        document.documentElement.style.setProperty('--vscode-badge-foreground', '#333333');
-        document.documentElement.style.setProperty('--vscode-settings-headerForeground', '#1e1e1e');
-        document.getElementById('surface-tabs').style.background = '#f3f3f3';
-        document.getElementById('surface-tabs').style.borderBottomColor = '#e0e0e0';
-        document.querySelectorAll('#surface-tabs button').forEach(b => b.style.color = '#555');
-      } else {
-        document.documentElement.style.setProperty('--vscode-editor-background', '#1e1e1e');
-        document.documentElement.style.setProperty('--vscode-editor-foreground', '#d4d4d4');
-        document.documentElement.style.setProperty('--vscode-sideBar-background', '#252526');
-        document.documentElement.style.setProperty('--vscode-panel-background', '#1e1e1e');
-        document.documentElement.style.setProperty('--vscode-panel-border', '#454545');
-        document.documentElement.style.setProperty('--vscode-list-hoverBackground', '#2a2d2e');
-        document.documentElement.style.setProperty('--vscode-list-inactiveSelectionBackground', '#37373d');
-        document.documentElement.style.setProperty('--vscode-descriptionForeground', '#8b949e');
-        document.documentElement.style.setProperty('--vscode-badge-background', '#4d4d4d');
-        document.documentElement.style.setProperty('--vscode-badge-foreground', '#ffffff');
-        document.documentElement.style.setProperty('--vscode-settings-headerForeground', '#e7e7e7');
-        document.getElementById('surface-tabs').style.background = '#252526';
-        document.getElementById('surface-tabs').style.borderBottomColor = '#454545';
-        document.querySelectorAll('#surface-tabs button').forEach(b => b.style.color = '#ccc');
-      }
-    }
-
-    // ── Boot: send initial state after webview mounts ────────────────────────
-    window.addEventListener('load', () => {
-      setTimeout(() => {
-        sendState('overview');
-      }, 200);
-    });
-  </script>
-</body>
+    </script>
+  </body>
 </html>

--- a/packages/webview/ui-preview.html
+++ b/packages/webview/ui-preview.html
@@ -1,0 +1,338 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Attractor UI Preview</title>
+
+  <!-- Mock VS Code CSS variables (Dark+ theme) -->
+  <style>
+    :root {
+      --vscode-editor-background: #1e1e1e;
+      --vscode-editor-foreground: #d4d4d4;
+      --vscode-sideBar-background: #252526;
+      --vscode-sideBar-foreground: #cccccc;
+      --vscode-panel-background: #1e1e1e;
+      --vscode-panel-border: #454545;
+      --vscode-button-background: #0e639c;
+      --vscode-button-foreground: #ffffff;
+      --vscode-button-hoverBackground: #1177bb;
+      --vscode-button-secondaryBackground: #3a3d41;
+      --vscode-button-secondaryForeground: #cccccc;
+      --vscode-button-secondaryHoverBackground: #44474b;
+      --vscode-input-background: #3c3c3c;
+      --vscode-input-foreground: #cccccc;
+      --vscode-input-border: #3c3c3c;
+      --vscode-focusBorder: #007fd4;
+      --vscode-errorForeground: #f48771;
+      --vscode-editorWarning-foreground: #cca700;
+      --vscode-editorInfo-foreground: #75beff;
+      --vscode-testing-iconPassed: #73c991;
+      --vscode-testing-iconFailed: #f48771;
+      --vscode-badge-background: #4d4d4d;
+      --vscode-badge-foreground: #ffffff;
+      --vscode-descriptionForeground: #8b949e;
+      --vscode-progressBar-background: #0e70c0;
+      --vscode-disabledForeground: #6d6d6d;
+      --vscode-inputValidation-errorBorder: #be1100;
+      --vscode-list-errorForeground: #f48771;
+      --vscode-list-hoverBackground: #2a2d2e;
+      --vscode-list-activeSelectionBackground: #094771;
+      --vscode-list-activeSelectionForeground: #ffffff;
+      --vscode-list-inactiveSelectionBackground: #37373d;
+      --vscode-textSeparator-foreground: #424242;
+      --vscode-tree-indentGuidesStroke: #585858;
+      --vscode-debugIcon-pauseForeground: #f48771;
+      --vscode-contrastBorder: transparent;
+      --vscode-contrastActiveBorder: transparent;
+      --vscode-notifications-background: #252526;
+      --vscode-charts-red: #f14c4c;
+      --vscode-charts-blue: #3794ff;
+      --vscode-charts-orange: #d18616;
+      --vscode-charts-green: #89d185;
+      --vscode-terminal-background: #1e1e1e;
+      --vscode-terminal-foreground: #cccccc;
+      --vscode-settings-headerForeground: #e7e7e7;
+      --vscode-textLink-foreground: #3794ff;
+      --vscode-textLink-activeForeground: #3794ff;
+      --vscode-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      --vscode-font-size: 13px;
+      --vscode-editor-font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
+    }
+
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    #surface-tabs {
+      display: flex;
+      background: #252526;
+      border-bottom: 1px solid #454545;
+      padding: 0 8px;
+      gap: 4px;
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 100;
+    }
+
+    #surface-tabs button {
+      padding: 6px 12px;
+      background: none;
+      border: none;
+      color: #ccc;
+      cursor: pointer;
+      font-size: 12px;
+      font-family: var(--vscode-font-family);
+      border-bottom: 2px solid transparent;
+      margin-bottom: -1px;
+    }
+
+    #surface-tabs button.active {
+      color: #fff;
+      border-bottom-color: #007acc;
+    }
+
+    #surface-tabs button:hover {
+      color: #fff;
+    }
+
+    #theme-toggle {
+      margin-left: auto;
+      padding: 4px 10px;
+      background: #3a3d41;
+      border: 1px solid #555;
+      color: #ccc;
+      cursor: pointer;
+      font-size: 11px;
+      border-radius: 3px;
+      align-self: center;
+    }
+
+    #app {
+      position: fixed;
+      top: 33px;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      overflow: hidden;
+    }
+  </style>
+  <link rel="stylesheet" href="bundle/webview.css" />
+</head>
+<body>
+
+  <div id="surface-tabs">
+    <button class="active" onclick="showSurface('overview')">Overview</button>
+    <button onclick="showSurface('repository')">Repository</button>
+    <button onclick="showSurface('plan')">Plan</button>
+    <button onclick="showSurface('run')">Run Inspector</button>
+    <button id="theme-toggle" onclick="toggleTheme()">Light Theme</button>
+  </div>
+
+  <div id="root"></div>
+
+  <script src="bundle/webview.js"></script>
+  <script>
+    // ── Mock data ──────────────────────────────────────────────────────────────
+
+    const OVERVIEW_STATE = {
+      stats: { totalRepos: 3, totalPlans: 7, activeRuns: 2, pausedRuns: 1, failedRuns24h: 1 },
+      repositories: [
+        { id: "repo-1", name: "my-app", defaultBranch: "main" },
+        { id: "repo-2", name: "infra-config", defaultBranch: "trunk" },
+        { id: "repo-3", name: "api-gateway", defaultBranch: "main" }
+      ],
+      activeRuns: [
+        { id: "run-abc123", planId: "plan-001", status: "running" },
+        { id: "run-def456", planId: "plan-002", status: "queued" }
+      ],
+      recentFailures: [
+        { id: "run-xyz789", planId: "plan-003", status: "failed" }
+      ],
+      error: null
+    };
+
+    const REPOSITORY_STATE = {
+      repository: {
+        id: "repo-1",
+        name: "my-app",
+        defaultBranch: "main",
+        labels: ["typescript", "frontend"]
+      },
+      plans: [
+        { id: "plan-001", title: "Feature: Add OAuth login", status: "running", updatedAt: "2026-03-29T12:00:00Z" },
+        { id: "plan-002", title: "Refactor: API client", status: "ready", updatedAt: "2026-03-28T09:00:00Z" },
+        { id: "plan-003", title: "Fix: Memory leak in cache", status: "completed", updatedAt: "2026-03-27T16:30:00Z" }
+      ],
+      runs: [
+        { id: "run-abc123", status: "running", attempt: 1, createdAt: "2026-03-29T11:00:00Z" },
+        { id: "run-old001", status: "completed", attempt: 2, createdAt: "2026-03-28T10:00:00Z" },
+        { id: "run-xyz789", status: "failed", attempt: 1, createdAt: "2026-03-27T16:00:00Z" }
+      ],
+      activity: [
+        { id: "evt-1", kind: "created", entityType: "plan", entityId: "plan-001", timestamp: "2026-03-29T11:55:00Z" },
+        { id: "evt-2", kind: "status.changed", entityType: "run", entityId: "run-abc123", timestamp: "2026-03-29T11:00:00Z" },
+        { id: "evt-3", kind: "artifact.created", entityType: "artifact", entityId: "art-001", timestamp: "2026-03-29T11:30:00Z" },
+        { id: "evt-4", kind: "validation.failed", entityType: "plan", entityId: "plan-003", timestamp: "2026-03-27T15:45:00Z" }
+      ]
+    };
+
+    const PLAN_STATE = {
+      plan: {
+        id: "plan-001",
+        title: "Feature: Add OAuth login",
+        goal: "Implement GitHub OAuth integration for single-sign-on, including callback handler, session management, and UI updates.",
+        status: "running",
+        graphSource: ".attractor/plans/oauth-login.dot",
+        createdAt: "2026-03-25T09:00:00Z",
+        updatedAt: "2026-03-29T12:00:00Z",
+        repositories: [
+          { repositoryId: "repo-1", role: "primary", access: "write", mountAlias: "app", ref: "feature/oauth" }
+        ]
+      },
+      milestones: [
+        { id: "m-1", title: "Research & Planning", order: 1, status: "completed", acceptanceCriteria: ["Documented OAuth flow", "Selected library"] },
+        { id: "m-2", title: "Backend Auth Endpoint", order: 2, status: "running", acceptanceCriteria: ["POST /auth/github", "Session created on success"] },
+        { id: "m-3", title: "Frontend Login UI", order: 3, status: "pending", acceptanceCriteria: ["Button renders", "Redirect works"] },
+        { id: "m-4", title: "E2E Tests", order: 4, status: "pending", acceptanceCriteria: ["Test login flow", "Test logout flow"] }
+      ],
+      history: [
+        { id: "run-old001", status: "failed", attempt: 1, createdAt: "2026-03-28T10:00:00Z" },
+        { id: "run-abc123", status: "running", attempt: 2, createdAt: "2026-03-29T11:00:00Z" }
+      ],
+      validationEvents: [
+        {
+          id: "evt-v1", kind: "status.changed", entityType: "plan", entityId: "plan-001",
+          entityKind: "plan", aggregateId: "plan-001", correlationId: "corr-1",
+          timestamp: "2026-03-29T11:00:00Z", payload: { reason: "Started run attempt 2" }
+        }
+      ]
+    };
+
+    const RUN_STATE = {
+      run: {
+        id: "run-abc123",
+        status: "running",
+        attempt: 2,
+        planId: "plan-001"
+      },
+      plan: {
+        id: "plan-001",
+        title: "Feature: Add OAuth login"
+      },
+      milestoneRuns: [
+        { id: "mr-1", nodeId: "research", status: "succeeded", startedAt: "2026-03-29T11:00:00Z", endedAt: "2026-03-29T11:15:00Z" },
+        { id: "mr-2", nodeId: "backend-auth", status: "running", startedAt: "2026-03-29T11:15:00Z" },
+        { id: "mr-3", nodeId: "frontend-ui", status: "queued", startedAt: "2026-03-29T11:00:00Z" },
+        { id: "mr-4", nodeId: "e2e-tests", status: "queued", startedAt: "2026-03-29T11:00:00Z" }
+      ],
+      artifacts: [
+        { id: "art-1", title: "oauth-research.md", type: "document", createdAt: "2026-03-29T11:14:00Z" },
+        { id: "art-2", title: "auth-endpoint.ts", type: "task-pack", createdAt: "2026-03-29T11:20:00Z" }
+      ],
+      currentHandoff: {
+        fromRole: "planner",
+        toRole: "implementer",
+        task: "Implement the POST /auth/github endpoint with session creation",
+        reason: "Planning phase complete. Implementation ready to begin."
+      }
+    };
+
+    // ── VS Code acquireVsCodeApi mock ────────────────────────────────────────
+    window.acquireVsCodeApi = function() {
+      return {
+        postMessage: function(msg) {
+          console.log('[mock vscode] postMessage:', msg);
+        },
+        getState: function() { return null; },
+        setState: function(state) { console.log('[mock vscode] setState:', state); }
+      };
+    };
+
+    // ── Surface switching ─────────────────────────────────────────────────────
+    let currentSurface = 'overview';
+
+    function sendState(surface) {
+      const msgMap = {
+        overview: { type: 'overview.state', payload: OVERVIEW_STATE },
+        repository: { type: 'repository.state', payload: REPOSITORY_STATE },
+        plan: { type: 'plan.state', payload: PLAN_STATE },
+        run: { type: 'run.state', payload: RUN_STATE }
+      };
+      const msg = msgMap[surface];
+      if (msg) {
+        window.dispatchEvent(new MessageEvent('message', { data: msg }));
+      }
+    }
+
+    function showSurface(surface) {
+      currentSurface = surface;
+
+      // Update tab buttons
+      document.querySelectorAll('#surface-tabs button:not(#theme-toggle)').forEach(btn => {
+        btn.classList.remove('active');
+      });
+      event.target.classList.add('active');
+
+      // Send navigate message then state
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'navigate', surface: surface }
+      }));
+
+      // Small delay to let navigation settle
+      setTimeout(() => sendState(surface), 50);
+    }
+
+    // ── Light theme support ──────────────────────────────────────────────────
+    let isLight = false;
+    function toggleTheme() {
+      isLight = !isLight;
+      document.getElementById('theme-toggle').textContent = isLight ? 'Dark Theme' : 'Light Theme';
+
+      if (isLight) {
+        document.documentElement.style.setProperty('--vscode-editor-background', '#ffffff');
+        document.documentElement.style.setProperty('--vscode-editor-foreground', '#1e1e1e');
+        document.documentElement.style.setProperty('--vscode-sideBar-background', '#f3f3f3');
+        document.documentElement.style.setProperty('--vscode-panel-background', '#ffffff');
+        document.documentElement.style.setProperty('--vscode-panel-border', '#e0e0e0');
+        document.documentElement.style.setProperty('--vscode-list-hoverBackground', '#e8e8e8');
+        document.documentElement.style.setProperty('--vscode-list-inactiveSelectionBackground', '#e4e6f1');
+        document.documentElement.style.setProperty('--vscode-descriptionForeground', '#717171');
+        document.documentElement.style.setProperty('--vscode-badge-background', '#c4c4c4');
+        document.documentElement.style.setProperty('--vscode-badge-foreground', '#333333');
+        document.documentElement.style.setProperty('--vscode-settings-headerForeground', '#1e1e1e');
+        document.getElementById('surface-tabs').style.background = '#f3f3f3';
+        document.getElementById('surface-tabs').style.borderBottomColor = '#e0e0e0';
+        document.querySelectorAll('#surface-tabs button').forEach(b => b.style.color = '#555');
+      } else {
+        document.documentElement.style.setProperty('--vscode-editor-background', '#1e1e1e');
+        document.documentElement.style.setProperty('--vscode-editor-foreground', '#d4d4d4');
+        document.documentElement.style.setProperty('--vscode-sideBar-background', '#252526');
+        document.documentElement.style.setProperty('--vscode-panel-background', '#1e1e1e');
+        document.documentElement.style.setProperty('--vscode-panel-border', '#454545');
+        document.documentElement.style.setProperty('--vscode-list-hoverBackground', '#2a2d2e');
+        document.documentElement.style.setProperty('--vscode-list-inactiveSelectionBackground', '#37373d');
+        document.documentElement.style.setProperty('--vscode-descriptionForeground', '#8b949e');
+        document.documentElement.style.setProperty('--vscode-badge-background', '#4d4d4d');
+        document.documentElement.style.setProperty('--vscode-badge-foreground', '#ffffff');
+        document.documentElement.style.setProperty('--vscode-settings-headerForeground', '#e7e7e7');
+        document.getElementById('surface-tabs').style.background = '#252526';
+        document.getElementById('surface-tabs').style.borderBottomColor = '#454545';
+        document.querySelectorAll('#surface-tabs button').forEach(b => b.style.color = '#ccc');
+      }
+    }
+
+    // ── Boot: send initial state after webview mounts ────────────────────────
+    window.addEventListener('load', () => {
+      setTimeout(() => {
+        sendState('overview');
+      }, 200);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Moves `ui-preview.html` from gitignored `packages/webview/dist/` to `packages/webview/` so it is tracked by git
- Updates `esbuild.config.mjs` to copy `ui-preview.html` to `dist/` during each build, so the preview server can still access it at the expected path
- Fixes the root mount point: `<div id="app">` → `<div id="root">`, matching the Preact entry in `client.ts` (`document.getElementById('root') ?? document.body`)

Without this fix the app mounted to `document.body`, overwriting the surface-tab nav bar and theme toggle in the developer preview harness.

Closes GLA-76.

## Test plan

- [ ] Run `node packages/webview/esbuild.config.mjs` — verify `dist/ui-preview.html` is produced with `<div id="root">`
- [ ] Open `dist/ui-preview.html` in a browser — confirm surface-tab nav bar and theme toggle are intact and navigable
- [ ] Confirm `packages/webview/ui-preview.html` is tracked by git and `packages/webview/dist/ui-preview.html` remains gitignored (generated artifact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)