### PR TITLE
fix(run): apply formatTimestamp to timeline and artifact timestamps (GLA-78)

### DIFF
--- a/packages/webview/src/run/RunSurface.tsx
+++ b/packages/webview/src/run/RunSurface.tsx
@@ -11,7 +11,7 @@ import {
   StatusBadge,
   type Status
 } from "../components";
-import { cn } from "../lib/utils";
+import { cn, formatTimestamp } from "../lib/utils";
 import type { RunState } from "./model";
 
 export interface RunSurfaceProps {
@@ -204,11 +204,11 @@ export function RunSurface({ state }: RunSurfaceProps): JSX.Element {
                         {milestoneRun.nodeId}
                       </div>
                       <div class="text-[length:var(--text-xs)] text-[color:var(--color-vscode-description)]">
-                        Started: {milestoneRun.startedAt}
+                        Started: {formatTimestamp(milestoneRun.startedAt)}
                       </div>
                       {milestoneRun.endedAt && (
                         <div class="text-[length:var(--text-xs)] text-[color:var(--color-vscode-description)]">
-                          Ended: {milestoneRun.endedAt}
+                          Ended: {formatTimestamp(milestoneRun.endedAt)}
                         </div>
                       )}
                       {milestoneRun.errorMessage && (
@@ -250,7 +250,7 @@ export function RunSurface({ state }: RunSurfaceProps): JSX.Element {
                       {artifact.title}
                     </div>
                     <div class="text-[length:var(--text-xs)] text-[color:var(--color-vscode-description)]">
-                      {artifact.createdAt}
+                      {formatTimestamp(artifact.createdAt)}
                     </div>
                   </div>
                   <Badge variant="outline">{artifact.type}</Badge>

--- a/packages/webview/test/run/run-surface.test.ts
+++ b/packages/webview/test/run/run-surface.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { RunSurface, buildRunViewModel } from "../../src/run/RunSurface";
+import { formatTimestamp } from "../../src/lib/utils";
 import type { RunState } from "../../src/run/model";
 
 function createState(overrides?: Partial<RunState>): RunState {
@@ -192,5 +193,47 @@ describe("RunSurface", () => {
       "task-pack",
       "report"
     ]);
+  });
+
+  it("timeline startedAt and endedAt are ISO strings that formatTimestamp can display", () => {
+    const vm = buildRunViewModel(createState());
+
+    // The view model carries raw ISO strings; formatTimestamp is applied in the
+    // JSX render layer (RunSurface.tsx) to convert them to HH:MM:SS.mmm display
+    // values. This test verifies the pipeline: raw ISO → formatTimestamp → short time.
+    const first = vm.timeline[0];
+    expect(first.startedAt).toBe("2026-01-10T10:01:00.000Z");
+    expect(first.endedAt).toBe("2026-01-10T10:05:00.000Z");
+
+    // Verify formatTimestamp converts to the expected short form.
+    // The exact hour depends on the local timezone; we verify structure only.
+    expect(formatTimestamp(first.startedAt)).toMatch(
+      /^\d{2}:\d{2}:\d{2}\.\d{3}$/
+    );
+    expect(formatTimestamp(first.endedAt!)).toMatch(
+      /^\d{2}:\d{2}:\d{2}\.\d{3}$/
+    );
+  });
+
+  it("timeline milestone with no endedAt passes undefined safely through formatTimestamp", () => {
+    const vm = buildRunViewModel(createState());
+
+    const running = vm.timeline[1];
+    expect(running.endedAt).toBeUndefined();
+
+    // formatTimestamp guards against null/undefined — returns "" for missing values.
+    expect(formatTimestamp(running.endedAt ?? "")).toBe("");
+  });
+
+  it("artifact createdAt is an ISO string that formatTimestamp can display", () => {
+    const vm = buildRunViewModel(createState());
+
+    const artifact = vm.artifacts[0];
+    expect(artifact.createdAt).toBe("2026-01-10T10:02:00.000Z");
+
+    // formatTimestamp is applied to createdAt in the JSX render layer.
+    expect(formatTimestamp(artifact.createdAt)).toMatch(
+      /^\d{2}:\d{2}:\d{2}\.\d{3}$/
+    );
   });
 });


### PR DESCRIPTION
## Summary

Timeline milestone rows and artifact rows in `RunSurface.tsx` were displaying raw ISO-8601 strings instead of the human-readable `HH:MM:SS.mmm` format used by all other timestamp displays in the webview.

**Root cause:** `formatTimestamp` (exported from `lib/utils` in [PR #37](https://github.com/nexaddo/vs-code-orchestrator-attractor/pull/37)) was not being called in the JSX render layer for `milestoneRun.startedAt`, `milestoneRun.endedAt`, or `artifact.createdAt`.

## Changes

- `packages/webview/src/run/RunSurface.tsx`
  - Import `formatTimestamp` alongside `cn` from `../lib/utils`
  - Wrap `milestoneRun.startedAt` with `formatTimestamp()` in the Timeline card
  - Wrap `milestoneRun.endedAt` with `formatTimestamp()` (conditional render already guards undefined)
  - Wrap `artifact.createdAt` with `formatTimestamp()` in the Artifacts card

- `packages/webview/test/run/run-surface.test.ts`
  - Import `formatTimestamp` from `../../src/lib/utils`
  - Add test: timeline `startedAt`/`endedAt` are ISO strings that `formatTimestamp` converts to `HH:MM:SS.mmm`
  - Add test: `endedAt` undefined guard — `formatTimestamp("")` returns `""`
  - Add test: artifact `createdAt` is an ISO string that `formatTimestamp` converts correctly

## Verification

- ✅ `pnpm typecheck` — clean
- ✅ `pnpm lint` — clean
- ✅ `pnpm test` — 532/532 pass
- ✅ `prettier --check` on changed files — clean

## Dependencies

This PR is stacked on top of [PR #37](https://github.com/nexaddo/vs-code-orchestrator-attractor/pull/37) (GLA-77: export `formatTimestamp` from `lib/utils`). Base branch is `fix/GLA-77-guard-format-timestamp`. After PR #37 merges, this PR's base should be retargeted to `main` before merging.