### PR TITLE
feat: add Open navigation buttons to plan and run rows in Repository surface (GLA-80)

### DIFF
--- a/packages/extension/src/dashboard/bridge.ts
+++ b/packages/extension/src/dashboard/bridge.ts
@@ -5,6 +5,7 @@ import { type ModelGateway } from "../application/ports";
 import { projectOverview } from "./overview-projection";
 import { projectRepository } from "./repository-projection";
 import { projectPlan } from "./plan-projection";
+import { projectRun } from "./run-projection";
 import { buildGraphUpdate } from "./graph-projection";
 
 /**
@@ -83,6 +84,30 @@ export async function handleWebviewMessage(
         version: 1,
         requestId: message.requestId,
         type: "plan.state",
+        payload: state
+      });
+      break;
+    }
+
+    case "plan.open": {
+      const planId = message.payload.planId as string;
+      const state = await projectPlan(planId, services);
+      await panel.postMessage({
+        version: 1,
+        requestId: message.requestId,
+        type: "plan.state",
+        payload: state
+      });
+      break;
+    }
+
+    case "run.open": {
+      const runId = message.payload.runId as string;
+      const state = await projectRun(runId, services);
+      await panel.postMessage({
+        version: 1,
+        requestId: message.requestId,
+        type: "run.state",
         payload: state
       });
       break;

--- a/packages/extension/test/dashboard/bridge.test.ts
+++ b/packages/extension/test/dashboard/bridge.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   type RepositoryRecord,
   type PlanRecord,
-  type MilestoneRecord
+  type MilestoneRecord,
+  type RunRecord
 } from "@attractor/shared";
 
 import { type StorageServices } from "../../src/storage/services";
@@ -62,6 +63,16 @@ const makeMilestone = (id: string, planId: string): MilestoneRecord => ({
   nodeIds: ["node1"]
 });
 
+const makeRun = (id: string, planId: string): RunRecord => ({
+  version: 1,
+  id,
+  planId,
+  status: "running",
+  attempt: 1,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString()
+});
+
 const makeServices = (overrides: {
   repositories?: RepositoryRecord[];
   planCount?: number;
@@ -69,6 +80,8 @@ const makeServices = (overrides: {
   repositoryById?: (id: string) => RepositoryRecord | null;
   plans?: PlanRecord[];
   milestones?: MilestoneRecord[];
+  runs?: RunRecord[];
+  runById?: (id: string) => RunRecord | null;
 }): StorageServices => {
   const repos = overrides.repositories ?? [];
   const planStubs =
@@ -77,19 +90,21 @@ const makeServices = (overrides: {
       { length: overrides.planCount ?? 0 },
       (_, i) => ({ id: `p${i}` }) as never
     );
-  const activeRunStubs = Array.from(
-    { length: overrides.activeRunCount ?? 0 },
-    (_, i) =>
-      ({
-        version: 1,
-        id: `run-${i}`,
-        planId: "plan-1",
-        status: "running",
-        attempt: 1,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
-      }) as never
-  );
+  const activeRunStubs =
+    overrides.runs ??
+    Array.from(
+      { length: overrides.activeRunCount ?? 0 },
+      (_, i) =>
+        ({
+          version: 1,
+          id: `run-${i}`,
+          planId: "plan-1",
+          status: "running",
+          attempt: 1,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
+        }) as never
+    );
 
   return {
     repositoryRegistry: {
@@ -111,7 +126,12 @@ const makeServices = (overrides: {
     },
     runRegistry: {
       save: notImplemented,
-      getById: notImplemented,
+      getById: async (id: string) => {
+        if (overrides.runById) {
+          return overrides.runById(id);
+        }
+        return activeRunStubs.find((r) => r.id === id) ?? null;
+      },
       list: async () => activeRunStubs,
       listActiveRuns: notImplemented
     },
@@ -120,7 +140,7 @@ const makeServices = (overrides: {
     milestoneRunRegistry: {
       save: notImplemented,
       getById: notImplemented,
-      listByRunId: notImplemented,
+      listByRunId: async () => [],
       listByMilestoneId: notImplemented
     },
     milestoneRegistry: {
@@ -132,7 +152,7 @@ const makeServices = (overrides: {
     artifactRegistry: {
       save: notImplemented,
       getById: notImplemented,
-      listByRunId: notImplemented,
+      listByRunId: async () => [],
       listByNodeId: notImplemented
     }
   };
@@ -817,6 +837,119 @@ describe("handleWebviewMessage — bridge", () => {
       expect(msg.type).toBe("toast");
       expect(msg.payload.severity).toBe("warning");
       expect(msg.payload.message).toContain("not yet supported");
+    });
+  });
+
+  describe("navigation routes", () => {
+    it("plan.open posts plan.state with correct payload", async () => {
+      const plan1 = makePlan("p1", "r1");
+      const milestone1 = makeMilestone("m1", "p1");
+      const services = makeServices({
+        plans: [plan1],
+        milestones: [milestone1]
+      });
+      const { panel, posted } = makePanel();
+
+      await handleWebviewMessage(
+        {
+          version: 1,
+          requestId: "req-plan-open",
+          type: "plan.open",
+          payload: { planId: "p1" }
+        },
+        services,
+        panel
+      );
+
+      expect(posted).toHaveLength(1);
+      const msg = posted[0] as {
+        version: number;
+        requestId: string;
+        type: string;
+        payload: unknown;
+      };
+      expect(msg.version).toBe(1);
+      expect(msg.requestId).toBe("req-plan-open");
+      expect(msg.type).toBe("plan.state");
+      expect(msg.payload).toBeDefined();
+    });
+
+    it("plan.open echoes the requestId", async () => {
+      const services = makeServices({
+        plans: [makePlan("p1", "r1")]
+      });
+      const { panel, posted } = makePanel();
+
+      await handleWebviewMessage(
+        {
+          version: 1,
+          requestId: "echo-plan-open-999",
+          type: "plan.open",
+          payload: { planId: "p1" }
+        },
+        services,
+        panel
+      );
+
+      const msg = posted[0] as { requestId: string };
+      expect(msg.requestId).toBe("echo-plan-open-999");
+    });
+
+    it("run.open posts run.state with correct payload", async () => {
+      const plan1 = makePlan("p1", "r1");
+      const run1 = makeRun("run-1", "p1");
+      const services = makeServices({
+        plans: [plan1],
+        runs: [run1]
+      });
+      const { panel, posted } = makePanel();
+
+      await handleWebviewMessage(
+        {
+          version: 1,
+          requestId: "req-run-open",
+          type: "run.open",
+          payload: { runId: "run-1" }
+        },
+        services,
+        panel
+      );
+
+      expect(posted).toHaveLength(1);
+      const msg = posted[0] as {
+        version: number;
+        requestId: string;
+        type: string;
+        payload: unknown;
+      };
+      expect(msg.version).toBe(1);
+      expect(msg.requestId).toBe("req-run-open");
+      expect(msg.type).toBe("run.state");
+      expect(msg.payload).toBeDefined();
+    });
+
+    it("run.open echoes the requestId", async () => {
+      const plan1 = makePlan("p1", "r1");
+      const run1 = makeRun("run-1", "p1");
+      const services = makeServices({
+        plans: [plan1],
+        runs: [run1]
+      });
+      const { panel, posted } = makePanel();
+
+      await handleWebviewMessage(
+        {
+          version: 1,
+          requestId: "echo-run-open-111",
+          type: "run.open",
+          payload: { runId: "run-1" }
+        },
+        services,
+        panel
+      );
+
+      const msg = posted[0] as { requestId: string };
+      expect(msg.requestId).toBe("echo-run-open-111");
     });
   });
 });

--- a/packages/shared/src/contracts/index.ts
+++ b/packages/shared/src/contracts/index.ts
@@ -17,8 +17,10 @@ export type RepositoryRecord = z.infer<typeof RepositoryRecordSchema>;
 export const WebviewInboundMessageTypeSchema = z.enum([
   "ready",
   "repository.open",
+  "plan.open",
   "plan.create",
   "plan.run",
+  "run.open",
   "run.resume",
   "run.cancel",
   "run.retry",

--- a/packages/webview/src/app/postMessage.ts
+++ b/packages/webview/src/app/postMessage.ts
@@ -41,6 +41,14 @@ export function openMilestone(planId: string): void {
   sendMessage("milestone.open", { planId });
 }
 
+export function openPlan(planId: string): void {
+  sendMessage("plan.open", { planId });
+}
+
+export function openRun(runId: string): void {
+  sendMessage("run.open", { runId });
+}
+
 export function focusGraphNode(nodeId: string, status: string): void {
   sendMessage("graph.focus", { nodeId, status });
 }

--- a/packages/webview/src/repository/RepositorySurface.tsx
+++ b/packages/webview/src/repository/RepositorySurface.tsx
@@ -12,6 +12,7 @@ import {
   type Status
 } from "../components";
 import { cn } from "../lib/utils";
+import { openPlan, openRun } from "../app/postMessage";
 import type { RepositoryState } from "./model";
 
 export interface RepositorySurfaceProps {
@@ -27,6 +28,7 @@ export interface RepositoryPlanViewModel {
 
 export interface RepositoryRunViewModel {
   id: string;
+  planId: string;
   status: Status;
   attempt: number;
   createdAt: string;
@@ -120,6 +122,7 @@ export function buildRepositoryViewModel(
     })),
     runs: state.runs.map((run) => ({
       id: run.id,
+      planId: run.planId,
       status: toRunStatusBadgeStatus(run.status),
       attempt: run.attempt,
       createdAt: run.createdAt
@@ -187,7 +190,16 @@ export function RepositorySurface({
                         {plan.updatedAt}
                       </div>
                     </div>
-                    <StatusBadge status={plan.status} variant="text" />
+                    <div class="flex shrink-0 items-center gap-2">
+                      <StatusBadge status={plan.status} variant="text" />
+                      <button
+                        type="button"
+                        class="text-[length:var(--text-xs)] text-[color:var(--color-vscode-text-link)] hover:underline"
+                        onClick={() => openPlan(plan.id)}
+                      >
+                        Open
+                      </button>
+                    </div>
                   </div>
                 </div>
               ))
@@ -225,7 +237,16 @@ export function RepositorySurface({
                           Attempt {run.attempt} · {run.createdAt}
                         </div>
                       </div>
-                      <StatusBadge status={run.status} variant="text" />
+                      <div class="flex shrink-0 items-center gap-2">
+                        <StatusBadge status={run.status} variant="text" />
+                        <button
+                          type="button"
+                          class="text-[length:var(--text-xs)] text-[color:var(--color-vscode-text-link)] hover:underline"
+                          onClick={() => openRun(run.id)}
+                        >
+                          Open
+                        </button>
+                      </div>
                     </div>
                   </div>
                 ))

--- a/packages/webview/test/repository/repository-surface.test.ts
+++ b/packages/webview/test/repository/repository-surface.test.ts
@@ -168,18 +168,21 @@ describe("RepositorySurface", () => {
     expect(vm.runs).toEqual([
       {
         id: "run-1",
+        planId: "plan-draft",
         status: "queued",
         attempt: 1,
         createdAt: "2026-01-20T00:00:00Z"
       },
       {
         id: "run-2",
+        planId: "plan-completed",
         status: "succeeded",
         attempt: 2,
         createdAt: "2026-01-21T00:00:00Z"
       },
       {
         id: "run-3",
+        planId: "plan-paused",
         status: "blocked",
         attempt: 1,
         createdAt: "2026-01-22T00:00:00Z"


### PR DESCRIPTION
## Summary

Implements GLA-80: adds "Open" navigation buttons to plan rows and run rows in the Repository surface of the VS Code webview extension.

## Changes

- **Contract** (`packages/shared/src/contracts/index.ts`): Added `plan.open` and `run.open` to `WebviewInboundMessageTypeSchema`
- **postMessage.ts**: Added `openPlan(planId)` and `openRun(runId)` typed message helpers
- **RepositorySurface.tsx**:
  - Added `planId` field to `RepositoryRunViewModel` (now carries the parent plan ID)
  - Updated `buildRepositoryViewModel` to map `run.planId`
  - Added "Open" button to each plan row (calls `openPlan`)
  - Added "Open" button to each run row (calls `openRun`)
- **bridge.ts**: Added `case "plan.open"` (delegates to `projectPlan`) and `case "run.open"` (delegates to `projectRun`), both responding with the correct state message type
- **Tests**: Failing-first TDD — added `planId` assertion to run VM tests; added `plan.open` and `run.open` bridge route tests

## Test Results

527/528 tests pass. The 1 failure (`vsix-content.test.ts`) is a pre-existing smoke test that requires `pnpm` which is not available in this environment — unrelated to these changes.

## Related

Closes GLA-80