### PR TITLE
feat: show only graph filename instead of full path in plan surface (#GLA-66)

### DIFF
--- a/docs/competitor-intel-april-2026.md
+++ b/docs/competitor-intel-april-2026.md
@@ -1,0 +1,237 @@
+# Attractor Competitive Intelligence — April 2026 Scan
+
+**Scanned**: 2026-04-02  
+**Context**: Attractor v0.1.0 released (M5) — multi-step AI coding orchestration via DOT digraph plans  
+**Prior Art Documented**: VS Code v1.109 Agent HQ, Agent Flow Builder, BLACKBOX AI  
+**Deferred Features**: `parallel`, `fan_in`, `tool`, `manager_loop` node types + multi-repo execution
+
+---
+
+## High-Relevance Findings (Graph/DOT/Multi-Agent Role Systems)
+
+### 1. TAKT — Agent Coordination Topology
+- **Repo**: [nrslib/takt](https://github.com/nrslib/takt)
+- **Stars**: 887 ⭐ | **Forks**: 49
+- **Description**: "TAKT Agent Koordination Topology - Define how AI agents coordinate, where humans intervene, and what gets recorded — in YAML"
+- **Key Features**:
+  - YAML-based agent coordination topology
+  - Explicit human-in-the-loop intervention points
+  - Recording/audit capabilities
+  - TypeScript-based
+- **Relevance**: **DIRECT COMPETITOR** — Same problem space (declarative agent orchestration). TAKT uses YAML; Attractor uses DOT. Both aim to define multi-agent coordination as code. TAKT's YAML approach is simpler but less expressive than DOT for complex DAGs.
+- **Assessment**: Monitor closely. Different formalism (YAML vs DOT) but same intent.
+
+---
+
+### 2. KubeRocketAI — Declarative Agentic SDLC
+- **Repo**: [KubeRocketCI/kuberocketai](https://github.com/KubeRocketCI/kuberocketai)
+- **Stars**: 31 ⭐ | **Forks**: 7
+- **Description**: "Declarative agentic framework for AI-driven software development. Define, validate, and orchestrate AI agents as code—transparent, auditable, and CI/CD-ready."
+- **Key Features**:
+  - SDLC-as-Code approach
+  - Pre-configured agent personas (Architect, Developer, DevOps, QA, etc.)
+  - Declarative YAML/Go-based configuration
+  - CI/CD integration
+- **Relevance**: **COMPLEMENT** — Different target (full SDLC vs per-file orchestration). KubeRocketAI manages entire development lifecycle; Attractor focuses on code generation plans. Could integrate.
+- **Assessment**: Interesting for future multi-repo/multi-agent features.
+
+---
+
+### 3. Mysti — Multi-Agent Collaboration
+- **Repo**: [DeepMyst/Mysti](https://github.com/DeepMyst/Mysti)
+- **Stars**: 1027 ⭐ | **Forks**: 43
+- **Marketplace**: [Mysti - AI Coding Agent](https://marketplace.visualstudio.com/items?itemName=DeepMyst.mysti) (2,891 installs)
+- **Description**: "AI coding dream team of agents for VS Code. Claude Code + OpenAI Codex collaborate in brainstorm mode, debate solutions, and synthesize the best approach."
+- **Key Features**:
+  - Multiple AI models (Claude, Codex, Gemini, Copilot)
+  - Brainstorm/debate mode between agents
+  - Synthesis of best approach
+  - Collaborative decision-making
+- **Relevance**: **COMPLEMENT** — Mysti coordinates multiple LLM backends. Attractor orchestrates steps within a single LLM session. Different abstraction layers.
+- **Assessment**: Strong competitor for multi-model use cases. Not plan-based (no DAG).
+
+---
+
+### 4. HermeX — Network of AI Agents
+- **Repo**: [HermeX-AI/hermex-ai-vscode](https://github.com/HermeX-AI/hermex-ai-vscode)
+- **Stars**: 1 ⭐ | **Forks**: 0
+- **Description**: "HermeX orchestrates a network of AI agents — Architect, Developer, Tester, Critic — to deliver production-ready features 10× faster."
+- **Key Features**:
+  - Role-based agent network (Architect, Developer, Tester, Critic)
+  - Pipeline workflow
+  - VS Code extension
+- **Relevance**: **DIRECT COMPETITOR** — Same role-based multi-agent concept as Attractor's planned `manager_loop`. HermeX defines explicit agent roles in a pipeline.
+- **Assessment**: Early stage (1 star). Role definitions align with Attractor's design philosophy.
+
+---
+
+### 5. workermill — Multi-Expert Orchestration
+- **Repo**: [jarod-rosenthal/workermill](https://github.com/jarod-rosenthal/workermill)
+- **Stars**: 4 ⭐ | **Forks**: 0
+- **Description**: "Open-source AI coding team with multi-expert orchestration"
+- **Key Features**:
+  - Multi-expert coordination
+  - CLI + VS Code extension
+  - Ollama support
+- **Relevance**: **COMPLEMENT** — Similar orchestration concept, different implementation.
+- **Assessment**: Niche player.
+
+---
+
+## Medium-Relevance Findings (Workflow/Tooling)
+
+### 6. kudosflow — Visual Workflow Editor
+- **Repo**: [akudo7/kudosflow](https://github.com/akudo7/kudosflow)
+- **Stars**: 9 ⭐ | **Forks**: 2
+- **Marketplace**: [kudosflow - LangChain extension](https://marketplace.visualstudio.com/items?itemName=AkiraKudo.kudosflow) (1,174 installs)
+- **Description**: "Visual workflow editor for building node-based AI agent workflows with drag-and-drop interface, A2A integration, and real-time execution"
+- **Key Features**:
+  - Drag-and-drop node editor (React Flow)
+  - A2A (Agent-to-Agent) protocol integration
+  - MCP support
+  - Real-time execution
+  - JSON export/import
+- **Relevance**: **COMPLEMENT** — Visual graph builder. Attractor uses DOT text format; kudosflow uses visual nodes. Could inspire DOT visualizer.
+- **Assessment**: Good reference for future visual plan editor.
+
+---
+
+### 7. FlowDrop — Visual Workflow Editor (External)
+- **URL**: [flowdrop.io](https://flowdrop.io/)
+- **Description**: "The visual workflow editor for AI agents. A drop-in component that lets your users design, configure, and manage AI workflows."
+- **Key Features**:
+  - Open source (MIT)
+  - Drop-in React component
+  - Any backend, any framework
+- **Relevance**: **COMPLEMENT** — Could be integrated as visual DOT renderer.
+- **Assessment**: Worth evaluating for plan visualization.
+
+---
+
+### 8. DebugMCP — Agent Debugging
+- **Repo**: [microsoft/DebugMCP](https://github.com/microsoft/DebugMCP)
+- **Stars**: 276 ⭐ | **Forks**: 17
+- **Description**: "Gift your VS Code agent a real debugger: breakpoints, stepping, inspection."
+- **Key Features**:
+  - Real breakpoints for AI agents
+  - Step-through debugging
+  - Variable inspection
+  - MCP integration
+- **Relevance**: **COMPLEMENT** — Debugging for AI agents is a gap in Attractor. Could add post-M5.
+- **Assessment**: Valuable integration target.
+
+---
+
+### 9. bitfrog-copilot — 7+1 Agent System
+- **Repo**: [rainyulei/bitfrog-copilot](https://github.com/rainyulei/bitfrog-copilot)
+- **Stars**: 12 ⭐ | **Forks**: 2
+- **Description**: "7+1 AI development agents for GitHub Copilot with Chinese philosophy-driven thinking models. Brainstorm, plan, execute, debug, review, mentor, and Mozi autonomous deep worker."
+- **Key Features**:
+  - 7 role-based agents + 1 autonomous
+  - Chinese philosophy thinking models
+  - TDD support
+  - Code review integration
+- **Relevance**: **COMPETITOR** — Role-based agents like HermeX.
+- **Assessment**: Interesting philosophical approach to agent roles.
+
+---
+
+### 10. nofx-vscode — Parallel Agents
+- **Repo**: [benfinklea/nofx-vscode](https://github.com/benfinklea/nofx-vscode)
+- **Stars**: 1 ⭐ | **Forks**: 0
+- **Description**: "VS Code extension for orchestrating multiple Claude Code AI agents in parallel"
+- **Relevance**: **DIRECT COMPETITOR** — Parallel execution matches Attractor's deferred `parallel` node type.
+- **Assessment**: Early stage but validates parallel orchestration need.
+
+---
+
+### 11. operator — Kanban-style Multi-Agent
+- **Repo**: [untra/operator](https://github.com/untra/operator)
+- **Stars**: 10 ⭐ | **Forks**: 1
+- **Description**: "Operator! Multi-agent orchestration application for AI assisted kanban shaped software development"
+- **Key Features**:
+  - Kanban-based workflow
+  - Claude Code, Codex, Gemini CLI support
+  - Git, Jira, Linear integration
+  - Tmux/Zellij terminal multiplexing
+- **Relevance**: **COMPLEMENT** — Different paradigm (Kanban vs DAG). Interesting for future workflow views.
+- **Assessment**: Novel approach to agent task management.
+
+---
+
+### 12. retort-plugins — Retort Orchestration
+- **Repo**: [phoenixvc/retort-plugins](https://github.com/phoenixvc/retort-plugins)
+- **Stars**: 0 ⭐ | **Forks**: 0
+- **Description**: "VSCode extension for Retort — command palette, sidebar, and status bar for AI agent orchestration"
+- **Relevance**: **COMPLEMENT** — Retort appears to be an orchestration framework.
+- **Assessment**: Monitor.
+
+---
+
+## Low-Relevance / Contextual
+
+### 13. Skill-Dock — Agent Skill Manager
+- **Repo**: [yen0304/Skill-Dock](https://github.com/yen0304/Skill-Dock)
+- **Stars**: 11 ⭐ | **Forks**: 1
+- **Description**: "Local-first agent skill manager for VS Code / Cursor. Manage, browse, and import skills across Claude, Cursor, Codex."
+- **Relevance**: **COMPLEMENT** — Skill management aligns with Attractor's skill system.
+- **Assessment**: Could integrate skill discovery.
+
+---
+
+### 14. Claude Code Guide (Educational)
+- **Repo**: [zebbern/claude-code-guide](https://github.com/zebbern/claude-code-guide)
+- **Stars**: 3789 ⭐ | **Forks**: 355
+- **Description**: "Claude Code Guide - Setup, Commands, workflows, agents, skills & tips-n-tricks"
+- **Relevance**: **IRRELEVANT** — Educational resource, not a competitor.
+
+---
+
+### 15. FlowiseAI — Visual AI Development Platform
+- **URL**: [flowiseai.com](https://flowiseai.com/)
+- **Description**: "Open source generative AI development platform. Modular building blocks for building any agentic systems."
+- **Relevance**: **COMPLEMENT** — Low-code visual agent builder. Not VS Code specific but worth watching.
+
+---
+
+## VS Code Native (Context)
+
+### VS Code 1.109+ Multi-Agent Support
+- **Reference**: [Your Home for Multi-Agent Development](https://code.visualstudio.com/blogs/2026/02/05/multi-agent-development)
+- **Key Features**:
+  - Native agent sessions
+  - Multiple agents (Claude, Codex) in parallel
+  - Agent-to-agent communication
+- **Relevance**: **CONTEXT** — Native competition. Attractor must differentiate on DOT-based plan execution vs native inline chat.
+
+---
+
+## Summary Table
+
+| Name | Stars | Type | Relevance | Notes |
+|------|-------|------|-----------|-------|
+| TAKT | 887 | Declarative topology | **COMPETITOR** | YAML-based agent coordination. Different formalism (YAML vs DOT). |
+| KubeRocketAI | 31 | SDLC framework | COMPLEMENT | Full SDLC. Could integrate for multi-repo. |
+| Mysti | 1027 | Multi-model collaboration | COMPLEMENT | Multi-LLM coordination. |
+| HermeX | 1 | Role-based network | **COMPETITOR** | Architect/Developer/Tester/Critic pipeline. |
+| kudosflow | 9 | Visual workflow | COMPLEMENT | React Flow visualizer. |
+| DebugMCP | 276 | Debugging | COMPLEMENT | Agent debugging gap. |
+| bitfrog-copilot | 12 | Role agents | COMPETITOR | 7+1 agent system. |
+| nofx-vscode | 1 | Parallel agents | **COMPETITOR** | Parallel execution. |
+| workermill | 4 | Multi-expert | COMPLEMENT | |
+| operator | 10 | Kanban | COMPLEMENT | Novel workflow view. |
+
+---
+
+## Action Items
+
+1. **Investigate TAKT** — Compare YAML topology to DOT plans. Identify differentiation opportunities.
+2. **Add to roadmap**: Visual DOT plan renderer (inspired by kudosflow/FlowDrop).
+3. **Add to roadmap**: Agent debugging support (DebugMCP integration).
+4. **Monitor HermeX / bitfrog** — Role-based agent patterns.
+5. **Consider parallel node implementation** — nofx-vscode validates demand.
+
+---
+
+*Last Updated: 2026-04-02*  
+*Scan Source: GitHub API, Web Search, VS Code Marketplace*

--- a/docs/competitor-intel-april-2026.md
+++ b/docs/competitor-intel-april-2026.md
@@ -10,6 +10,7 @@
 ## High-Relevance Findings (Graph/DOT/Multi-Agent Role Systems)
 
 ### 1. TAKT — Agent Coordination Topology
+
 - **Repo**: [nrslib/takt](https://github.com/nrslib/takt)
 - **Stars**: 887 ⭐ | **Forks**: 49
 - **Description**: "TAKT Agent Koordination Topology - Define how AI agents coordinate, where humans intervene, and what gets recorded — in YAML"
@@ -24,6 +25,7 @@
 ---
 
 ### 2. KubeRocketAI — Declarative Agentic SDLC
+
 - **Repo**: [KubeRocketCI/kuberocketai](https://github.com/KubeRocketCI/kuberocketai)
 - **Stars**: 31 ⭐ | **Forks**: 7
 - **Description**: "Declarative agentic framework for AI-driven software development. Define, validate, and orchestrate AI agents as code—transparent, auditable, and CI/CD-ready."
@@ -38,6 +40,7 @@
 ---
 
 ### 3. Mysti — Multi-Agent Collaboration
+
 - **Repo**: [DeepMyst/Mysti](https://github.com/DeepMyst/Mysti)
 - **Stars**: 1027 ⭐ | **Forks**: 43
 - **Marketplace**: [Mysti - AI Coding Agent](https://marketplace.visualstudio.com/items?itemName=DeepMyst.mysti) (2,891 installs)
@@ -53,6 +56,7 @@
 ---
 
 ### 4. HermeX — Network of AI Agents
+
 - **Repo**: [HermeX-AI/hermex-ai-vscode](https://github.com/HermeX-AI/hermex-ai-vscode)
 - **Stars**: 1 ⭐ | **Forks**: 0
 - **Description**: "HermeX orchestrates a network of AI agents — Architect, Developer, Tester, Critic — to deliver production-ready features 10× faster."
@@ -66,6 +70,7 @@
 ---
 
 ### 5. workermill — Multi-Expert Orchestration
+
 - **Repo**: [jarod-rosenthal/workermill](https://github.com/jarod-rosenthal/workermill)
 - **Stars**: 4 ⭐ | **Forks**: 0
 - **Description**: "Open-source AI coding team with multi-expert orchestration"
@@ -81,6 +86,7 @@
 ## Medium-Relevance Findings (Workflow/Tooling)
 
 ### 6. kudosflow — Visual Workflow Editor
+
 - **Repo**: [akudo7/kudosflow](https://github.com/akudo7/kudosflow)
 - **Stars**: 9 ⭐ | **Forks**: 2
 - **Marketplace**: [kudosflow - LangChain extension](https://marketplace.visualstudio.com/items?itemName=AkiraKudo.kudosflow) (1,174 installs)
@@ -97,6 +103,7 @@
 ---
 
 ### 7. FlowDrop — Visual Workflow Editor (External)
+
 - **URL**: [flowdrop.io](https://flowdrop.io/)
 - **Description**: "The visual workflow editor for AI agents. A drop-in component that lets your users design, configure, and manage AI workflows."
 - **Key Features**:
@@ -109,6 +116,7 @@
 ---
 
 ### 8. DebugMCP — Agent Debugging
+
 - **Repo**: [microsoft/DebugMCP](https://github.com/microsoft/DebugMCP)
 - **Stars**: 276 ⭐ | **Forks**: 17
 - **Description**: "Gift your VS Code agent a real debugger: breakpoints, stepping, inspection."
@@ -123,6 +131,7 @@
 ---
 
 ### 9. bitfrog-copilot — 7+1 Agent System
+
 - **Repo**: [rainyulei/bitfrog-copilot](https://github.com/rainyulei/bitfrog-copilot)
 - **Stars**: 12 ⭐ | **Forks**: 2
 - **Description**: "7+1 AI development agents for GitHub Copilot with Chinese philosophy-driven thinking models. Brainstorm, plan, execute, debug, review, mentor, and Mozi autonomous deep worker."
@@ -137,6 +146,7 @@
 ---
 
 ### 10. nofx-vscode — Parallel Agents
+
 - **Repo**: [benfinklea/nofx-vscode](https://github.com/benfinklea/nofx-vscode)
 - **Stars**: 1 ⭐ | **Forks**: 0
 - **Description**: "VS Code extension for orchestrating multiple Claude Code AI agents in parallel"
@@ -146,6 +156,7 @@
 ---
 
 ### 11. operator — Kanban-style Multi-Agent
+
 - **Repo**: [untra/operator](https://github.com/untra/operator)
 - **Stars**: 10 ⭐ | **Forks**: 1
 - **Description**: "Operator! Multi-agent orchestration application for AI assisted kanban shaped software development"
@@ -160,6 +171,7 @@
 ---
 
 ### 12. retort-plugins — Retort Orchestration
+
 - **Repo**: [phoenixvc/retort-plugins](https://github.com/phoenixvc/retort-plugins)
 - **Stars**: 0 ⭐ | **Forks**: 0
 - **Description**: "VSCode extension for Retort — command palette, sidebar, and status bar for AI agent orchestration"
@@ -171,6 +183,7 @@
 ## Low-Relevance / Contextual
 
 ### 13. Skill-Dock — Agent Skill Manager
+
 - **Repo**: [yen0304/Skill-Dock](https://github.com/yen0304/Skill-Dock)
 - **Stars**: 11 ⭐ | **Forks**: 1
 - **Description**: "Local-first agent skill manager for VS Code / Cursor. Manage, browse, and import skills across Claude, Cursor, Codex."
@@ -180,6 +193,7 @@
 ---
 
 ### 14. Claude Code Guide (Educational)
+
 - **Repo**: [zebbern/claude-code-guide](https://github.com/zebbern/claude-code-guide)
 - **Stars**: 3789 ⭐ | **Forks**: 355
 - **Description**: "Claude Code Guide - Setup, Commands, workflows, agents, skills & tips-n-tricks"
@@ -188,6 +202,7 @@
 ---
 
 ### 15. FlowiseAI — Visual AI Development Platform
+
 - **URL**: [flowiseai.com](https://flowiseai.com/)
 - **Description**: "Open source generative AI development platform. Modular building blocks for building any agentic systems."
 - **Relevance**: **COMPLEMENT** — Low-code visual agent builder. Not VS Code specific but worth watching.
@@ -197,6 +212,7 @@
 ## VS Code Native (Context)
 
 ### VS Code 1.109+ Multi-Agent Support
+
 - **Reference**: [Your Home for Multi-Agent Development](https://code.visualstudio.com/blogs/2026/02/05/multi-agent-development)
 - **Key Features**:
   - Native agent sessions
@@ -208,18 +224,18 @@
 
 ## Summary Table
 
-| Name | Stars | Type | Relevance | Notes |
-|------|-------|------|-----------|-------|
-| TAKT | 887 | Declarative topology | **COMPETITOR** | YAML-based agent coordination. Different formalism (YAML vs DOT). |
-| KubeRocketAI | 31 | SDLC framework | COMPLEMENT | Full SDLC. Could integrate for multi-repo. |
-| Mysti | 1027 | Multi-model collaboration | COMPLEMENT | Multi-LLM coordination. |
-| HermeX | 1 | Role-based network | **COMPETITOR** | Architect/Developer/Tester/Critic pipeline. |
-| kudosflow | 9 | Visual workflow | COMPLEMENT | React Flow visualizer. |
-| DebugMCP | 276 | Debugging | COMPLEMENT | Agent debugging gap. |
-| bitfrog-copilot | 12 | Role agents | COMPETITOR | 7+1 agent system. |
-| nofx-vscode | 1 | Parallel agents | **COMPETITOR** | Parallel execution. |
-| workermill | 4 | Multi-expert | COMPLEMENT | |
-| operator | 10 | Kanban | COMPLEMENT | Novel workflow view. |
+| Name            | Stars | Type                      | Relevance      | Notes                                                             |
+| --------------- | ----- | ------------------------- | -------------- | ----------------------------------------------------------------- |
+| TAKT            | 887   | Declarative topology      | **COMPETITOR** | YAML-based agent coordination. Different formalism (YAML vs DOT). |
+| KubeRocketAI    | 31    | SDLC framework            | COMPLEMENT     | Full SDLC. Could integrate for multi-repo.                        |
+| Mysti           | 1027  | Multi-model collaboration | COMPLEMENT     | Multi-LLM coordination.                                           |
+| HermeX          | 1     | Role-based network        | **COMPETITOR** | Architect/Developer/Tester/Critic pipeline.                       |
+| kudosflow       | 9     | Visual workflow           | COMPLEMENT     | React Flow visualizer.                                            |
+| DebugMCP        | 276   | Debugging                 | COMPLEMENT     | Agent debugging gap.                                              |
+| bitfrog-copilot | 12    | Role agents               | COMPETITOR     | 7+1 agent system.                                                 |
+| nofx-vscode     | 1     | Parallel agents           | **COMPETITOR** | Parallel execution.                                               |
+| workermill      | 4     | Multi-expert              | COMPLEMENT     |                                                                   |
+| operator        | 10    | Kanban                    | COMPLEMENT     | Novel workflow view.                                              |
 
 ---
 
@@ -233,5 +249,5 @@
 
 ---
 
-*Last Updated: 2026-04-02*  
-*Scan Source: GitHub API, Web Search, VS Code Marketplace*
+_Last Updated: 2026-04-02_  
+_Scan Source: GitHub API, Web Search, VS Code Marketplace_

--- a/packages/extension/src/dashboard/bridge.ts
+++ b/packages/extension/src/dashboard/bridge.ts
@@ -5,6 +5,7 @@ import { type ModelGateway } from "../application/ports";
 import { projectOverview } from "./overview-projection";
 import { projectRepository } from "./repository-projection";
 import { projectPlan } from "./plan-projection";
+import { projectRun } from "./run-projection";
 import { buildGraphUpdate } from "./graph-projection";
 
 /**
@@ -83,6 +84,30 @@ export async function handleWebviewMessage(
         version: 1,
         requestId: message.requestId,
         type: "plan.state",
+        payload: state
+      });
+      break;
+    }
+
+    case "plan.open": {
+      const planId = message.payload.planId as string;
+      const state = await projectPlan(planId, services);
+      await panel.postMessage({
+        version: 1,
+        requestId: message.requestId,
+        type: "plan.state",
+        payload: state
+      });
+      break;
+    }
+
+    case "run.open": {
+      const runId = message.payload.runId as string;
+      const state = await projectRun(runId, services);
+      await panel.postMessage({
+        version: 1,
+        requestId: message.requestId,
+        type: "run.state",
         payload: state
       });
       break;

--- a/packages/extension/src/dashboard/plan-projection.ts
+++ b/packages/extension/src/dashboard/plan-projection.ts
@@ -1,5 +1,6 @@
 import {
   type ExtensionEvent,
+  type PlanRepositoryRef,
   type PlanStatePayload,
   type RunRecord
 } from "@attractor/shared";
@@ -9,7 +10,8 @@ import { type StorageServices } from "../storage/services";
 /**
  * Projects the current storage state into a PlanStatePayload for a given plan ID.
  *
- * - plan: the plan record identified by planId
+ * - plan: the plan record identified by planId, with repository refs enriched with
+ *         `name` from the repository registry (when available)
  * - milestones: array of milestones associated with the plan
  * - history: array of runs executed for this plan
  * - validationEvents: array of validation.failed events from all runs in history, sorted by timestamp ascending
@@ -25,6 +27,18 @@ export async function projectPlan(
   if (!plan) {
     throw new Error(`Plan not found: ${planId}`);
   }
+
+  const enrichedRepositories: PlanRepositoryRef[] = await Promise.all(
+    plan.repositories.map(async (repo) => {
+      const repoRecord = await services.repositoryRegistry.getById(
+        repo.repositoryId
+      );
+      if (repoRecord) {
+        return { ...repo, name: repoRecord.name };
+      }
+      return repo;
+    })
+  );
 
   // Fetch milestones for this plan
   const milestones = await services.milestoneRegistry.listByPlanId(planId);
@@ -49,7 +63,7 @@ export async function projectPlan(
   validationEvents.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
 
   return {
-    plan,
+    plan: { ...plan, repositories: enrichedRepositories },
     milestones,
     history,
     validationEvents

--- a/packages/extension/test/dashboard/bridge.test.ts
+++ b/packages/extension/test/dashboard/bridge.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   type RepositoryRecord,
   type PlanRecord,
-  type MilestoneRecord
+  type MilestoneRecord,
+  type RunRecord
 } from "@attractor/shared";
 
 import { type StorageServices } from "../../src/storage/services";
@@ -62,6 +63,16 @@ const makeMilestone = (id: string, planId: string): MilestoneRecord => ({
   nodeIds: ["node1"]
 });
 
+const makeRun = (id: string, planId: string): RunRecord => ({
+  version: 1,
+  id,
+  planId,
+  status: "running",
+  attempt: 1,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString()
+});
+
 const makeServices = (overrides: {
   repositories?: RepositoryRecord[];
   planCount?: number;
@@ -69,6 +80,8 @@ const makeServices = (overrides: {
   repositoryById?: (id: string) => RepositoryRecord | null;
   plans?: PlanRecord[];
   milestones?: MilestoneRecord[];
+  runs?: RunRecord[];
+  runById?: (id: string) => RunRecord | null;
 }): StorageServices => {
   const repos = overrides.repositories ?? [];
   const planStubs =
@@ -77,19 +90,21 @@ const makeServices = (overrides: {
       { length: overrides.planCount ?? 0 },
       (_, i) => ({ id: `p${i}` }) as never
     );
-  const activeRunStubs = Array.from(
-    { length: overrides.activeRunCount ?? 0 },
-    (_, i) =>
-      ({
-        version: 1,
-        id: `run-${i}`,
-        planId: "plan-1",
-        status: "running",
-        attempt: 1,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
-      }) as never
-  );
+  const activeRunStubs =
+    overrides.runs ??
+    Array.from(
+      { length: overrides.activeRunCount ?? 0 },
+      (_, i) =>
+        ({
+          version: 1,
+          id: `run-${i}`,
+          planId: "plan-1",
+          status: "running",
+          attempt: 1,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
+        }) as never
+    );
 
   return {
     repositoryRegistry: {
@@ -111,7 +126,12 @@ const makeServices = (overrides: {
     },
     runRegistry: {
       save: notImplemented,
-      getById: notImplemented,
+      getById: async (id: string) => {
+        if (overrides.runById) {
+          return overrides.runById(id);
+        }
+        return activeRunStubs.find((r) => r.id === id) ?? null;
+      },
       list: async () => activeRunStubs,
       listActiveRuns: notImplemented
     },
@@ -120,7 +140,7 @@ const makeServices = (overrides: {
     milestoneRunRegistry: {
       save: notImplemented,
       getById: notImplemented,
-      listByRunId: notImplemented,
+      listByRunId: async () => [],
       listByMilestoneId: notImplemented
     },
     milestoneRegistry: {
@@ -132,7 +152,7 @@ const makeServices = (overrides: {
     artifactRegistry: {
       save: notImplemented,
       getById: notImplemented,
-      listByRunId: notImplemented,
+      listByRunId: async () => [],
       listByNodeId: notImplemented
     }
   };
@@ -817,6 +837,119 @@ describe("handleWebviewMessage — bridge", () => {
       expect(msg.type).toBe("toast");
       expect(msg.payload.severity).toBe("warning");
       expect(msg.payload.message).toContain("not yet supported");
+    });
+  });
+
+  describe("navigation routes", () => {
+    it("plan.open posts plan.state with correct payload", async () => {
+      const plan1 = makePlan("p1", "r1");
+      const milestone1 = makeMilestone("m1", "p1");
+      const services = makeServices({
+        plans: [plan1],
+        milestones: [milestone1]
+      });
+      const { panel, posted } = makePanel();
+
+      await handleWebviewMessage(
+        {
+          version: 1,
+          requestId: "req-plan-open",
+          type: "plan.open",
+          payload: { planId: "p1" }
+        },
+        services,
+        panel
+      );
+
+      expect(posted).toHaveLength(1);
+      const msg = posted[0] as {
+        version: number;
+        requestId: string;
+        type: string;
+        payload: unknown;
+      };
+      expect(msg.version).toBe(1);
+      expect(msg.requestId).toBe("req-plan-open");
+      expect(msg.type).toBe("plan.state");
+      expect(msg.payload).toBeDefined();
+    });
+
+    it("plan.open echoes the requestId", async () => {
+      const services = makeServices({
+        plans: [makePlan("p1", "r1")]
+      });
+      const { panel, posted } = makePanel();
+
+      await handleWebviewMessage(
+        {
+          version: 1,
+          requestId: "echo-plan-open-999",
+          type: "plan.open",
+          payload: { planId: "p1" }
+        },
+        services,
+        panel
+      );
+
+      const msg = posted[0] as { requestId: string };
+      expect(msg.requestId).toBe("echo-plan-open-999");
+    });
+
+    it("run.open posts run.state with correct payload", async () => {
+      const plan1 = makePlan("p1", "r1");
+      const run1 = makeRun("run-1", "p1");
+      const services = makeServices({
+        plans: [plan1],
+        runs: [run1]
+      });
+      const { panel, posted } = makePanel();
+
+      await handleWebviewMessage(
+        {
+          version: 1,
+          requestId: "req-run-open",
+          type: "run.open",
+          payload: { runId: "run-1" }
+        },
+        services,
+        panel
+      );
+
+      expect(posted).toHaveLength(1);
+      const msg = posted[0] as {
+        version: number;
+        requestId: string;
+        type: string;
+        payload: unknown;
+      };
+      expect(msg.version).toBe(1);
+      expect(msg.requestId).toBe("req-run-open");
+      expect(msg.type).toBe("run.state");
+      expect(msg.payload).toBeDefined();
+    });
+
+    it("run.open echoes the requestId", async () => {
+      const plan1 = makePlan("p1", "r1");
+      const run1 = makeRun("run-1", "p1");
+      const services = makeServices({
+        plans: [plan1],
+        runs: [run1]
+      });
+      const { panel, posted } = makePanel();
+
+      await handleWebviewMessage(
+        {
+          version: 1,
+          requestId: "echo-run-open-111",
+          type: "run.open",
+          payload: { runId: "run-1" }
+        },
+        services,
+        panel
+      );
+
+      const msg = posted[0] as { requestId: string };
+      expect(msg.requestId).toBe("echo-run-open-111");
     });
   });
 });

--- a/packages/extension/test/dashboard/plan-projection.test.ts
+++ b/packages/extension/test/dashboard/plan-projection.test.ts
@@ -5,6 +5,7 @@ import {
   type ExtensionEvent,
   type MilestoneRecord,
   type PlanRecord,
+  type RepositoryRecord,
   type RunRecord
 } from "@attractor/shared";
 
@@ -87,16 +88,18 @@ const makeServices = (overrides: {
   milestones?: MilestoneRecord[];
   allRuns?: RunRecord[];
   eventsByRunId?: Map<string, ExtensionEvent[]>;
+  repositoriesById?: Map<string, RepositoryRecord>;
 }): StorageServices => {
   const plan = overrides.plan ?? null;
   const milestones = overrides.milestones ?? [];
   const allRuns = overrides.allRuns ?? [];
   const eventsByRunId = overrides.eventsByRunId ?? new Map();
+  const repositoriesById = overrides.repositoriesById ?? new Map();
 
   return {
     repositoryRegistry: {
       save: notImplemented,
-      getById: notImplemented,
+      getById: async (id: string) => repositoriesById.get(id) ?? null,
       list: async () => notImplemented()
     },
     planRegistry: {
@@ -276,5 +279,46 @@ describe("projectPlan", () => {
     expect(state.validationEvents[0]!.id).toBe("v2");
     expect(state.validationEvents[1]!.id).toBe("v3");
     expect(state.validationEvents[2]!.id).toBe("v1");
+  });
+
+  it("enriches plan repositories with names from repositoryRegistry", async () => {
+    const plan = makePlan("p1");
+    const repoRecord: RepositoryRecord = {
+      version: CONTRACT_VERSION,
+      id: "repo-1",
+      name: "my-app",
+      rootUri: "/workspace/my-app",
+      defaultBranch: "main",
+      labels: []
+    };
+    const repositoriesById = new Map<string, RepositoryRecord>([
+      ["repo-1", repoRecord]
+    ]);
+
+    const services = makeServices({
+      plan,
+      milestones: [],
+      allRuns: [],
+      repositoriesById
+    });
+
+    const state = await projectPlan("p1", services);
+
+    expect(state.plan.repositories[0]!.name).toBe("my-app");
+  });
+
+  it("leaves repository name undefined when not found in registry", async () => {
+    const plan = makePlan("p1");
+
+    const services = makeServices({
+      plan,
+      milestones: [],
+      allRuns: [],
+      repositoriesById: new Map()
+    });
+
+    const state = await projectPlan("p1", services);
+
+    expect(state.plan.repositories[0]!.name).toBeUndefined();
   });
 });

--- a/packages/shared/src/contracts/index.ts
+++ b/packages/shared/src/contracts/index.ts
@@ -65,6 +65,7 @@ export const PlanRepositoryAccessSchema = z.enum(["read_write", "read_only"]);
 
 export const PlanRepositoryRefSchema = z.object({
   repositoryId: z.string().min(1),
+  name: z.string().min(1).optional(),
   role: PlanRepositoryRoleSchema,
   access: PlanRepositoryAccessSchema,
   mountAlias: z.string().min(1),

--- a/packages/shared/src/contracts/index.ts
+++ b/packages/shared/src/contracts/index.ts
@@ -17,8 +17,10 @@ export type RepositoryRecord = z.infer<typeof RepositoryRecordSchema>;
 export const WebviewInboundMessageTypeSchema = z.enum([
   "ready",
   "repository.open",
+  "plan.open",
   "plan.create",
   "plan.run",
+  "run.open",
   "run.resume",
   "run.cancel",
   "run.retry",

--- a/packages/webview/src/app/postMessage.ts
+++ b/packages/webview/src/app/postMessage.ts
@@ -41,6 +41,14 @@ export function openMilestone(planId: string): void {
   sendMessage("milestone.open", { planId });
 }
 
+export function openPlan(planId: string): void {
+  sendMessage("plan.open", { planId });
+}
+
+export function openRun(runId: string): void {
+  sendMessage("run.open", { runId });
+}
+
 export function focusGraphNode(nodeId: string, status: string): void {
   sendMessage("graph.focus", { nodeId, status });
 }

--- a/packages/webview/src/plan/PlanSurface.tsx
+++ b/packages/webview/src/plan/PlanSurface.tsx
@@ -21,8 +21,10 @@ export interface PlanSurfaceProps {
 
 export interface PlanRepositoryViewModel {
   repositoryId: string;
+  name?: string | undefined;
   role: string;
   access: string;
+  accessLabel: string;
   mountAlias: string;
   ref?: string | undefined;
 }
@@ -192,8 +194,11 @@ export function buildPlanViewModel(state: PlanState): PlanViewModel {
     updatedAt: state.plan.updatedAt,
     repositories: state.plan.repositories.map((repository) => ({
       repositoryId: repository.repositoryId,
+      name: repository.name,
       role: repository.role,
       access: repository.access,
+      accessLabel:
+        repository.access === "read_write" ? "Writable" : "Read-only",
       mountAlias: repository.mountAlias,
       ref: repository.ref
     })),
@@ -257,10 +262,10 @@ export function PlanSurface({ state }: PlanSurfaceProps): JSX.Element {
                 >
                   <div class="flex items-center justify-between gap-2">
                     <span class="truncate font-medium">
-                      {repository.repositoryId}
+                      {repository.name ?? repository.repositoryId}
                     </span>
                     <span class="uppercase tracking-wide text-[color:var(--color-vscode-description)]">
-                      {repository.access}
+                      {repository.accessLabel}
                     </span>
                   </div>
                   <div class="mt-1 text-[color:var(--color-vscode-description)]">

--- a/packages/webview/src/plan/PlanSurface.tsx
+++ b/packages/webview/src/plan/PlanSurface.tsx
@@ -15,6 +15,17 @@ import {
 import { cn } from "../lib/utils";
 import type { PlanState } from "./model";
 
+/**
+ * Extract the filename from a file path (Unix or Windows style).
+ * Examples: ".attractor/plans/oauth-login.dot" -> "oauth-login.dot"
+ *           "C:\\plans\\flow.dot" -> "flow.dot"
+ */
+function extractFilename(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, "/");
+  const lastSlash = normalized.lastIndexOf("/");
+  return lastSlash === -1 ? filePath : normalized.slice(lastSlash + 1);
+}
+
 export interface PlanSurfaceProps {
   state: PlanState;
 }
@@ -242,7 +253,7 @@ export function PlanSurface({ state }: PlanSurfaceProps): JSX.Element {
         </CardHeader>
         <CardContent class="space-y-2">
           <div class="text-[length:var(--text-xs)] text-[color:var(--color-vscode-description)]">
-            Graph Source: {viewModel.graphSource}
+            Graph: {extractFilename(viewModel.graphSource)}
           </div>
           <div class="text-[length:var(--text-xs)] text-[color:var(--color-vscode-description)]">
             Created: {viewModel.createdAt} · Updated: {viewModel.updatedAt}

--- a/packages/webview/src/repository/RepositorySurface.tsx
+++ b/packages/webview/src/repository/RepositorySurface.tsx
@@ -12,6 +12,7 @@ import {
   type Status
 } from "../components";
 import { cn } from "../lib/utils";
+import { openPlan, openRun } from "../app/postMessage";
 import type { RepositoryState } from "./model";
 
 export interface RepositorySurfaceProps {
@@ -27,6 +28,7 @@ export interface RepositoryPlanViewModel {
 
 export interface RepositoryRunViewModel {
   id: string;
+  planId: string;
   status: Status;
   attempt: number;
   createdAt: string;
@@ -120,6 +122,7 @@ export function buildRepositoryViewModel(
     })),
     runs: state.runs.map((run) => ({
       id: run.id,
+      planId: run.planId,
       status: toRunStatusBadgeStatus(run.status),
       attempt: run.attempt,
       createdAt: run.createdAt
@@ -187,7 +190,16 @@ export function RepositorySurface({
                         {plan.updatedAt}
                       </div>
                     </div>
-                    <StatusBadge status={plan.status} variant="text" />
+                    <div class="flex shrink-0 items-center gap-2">
+                      <StatusBadge status={plan.status} variant="text" />
+                      <button
+                        type="button"
+                        class="text-[length:var(--text-xs)] text-[color:var(--color-vscode-text-link)] hover:underline"
+                        onClick={() => openPlan(plan.id)}
+                      >
+                        Open
+                      </button>
+                    </div>
                   </div>
                 </div>
               ))
@@ -225,7 +237,16 @@ export function RepositorySurface({
                           Attempt {run.attempt} · {run.createdAt}
                         </div>
                       </div>
-                      <StatusBadge status={run.status} variant="text" />
+                      <div class="flex shrink-0 items-center gap-2">
+                        <StatusBadge status={run.status} variant="text" />
+                        <button
+                          type="button"
+                          class="text-[length:var(--text-xs)] text-[color:var(--color-vscode-text-link)] hover:underline"
+                          onClick={() => openRun(run.id)}
+                        >
+                          Open
+                        </button>
+                      </div>
                     </div>
                   </div>
                 ))

--- a/packages/webview/src/run/RunSurface.tsx
+++ b/packages/webview/src/run/RunSurface.tsx
@@ -12,6 +12,7 @@ import {
   type Status
 } from "../components";
 import { cn } from "../lib/utils";
+import { openPlan } from "../app/postMessage";
 import type { RunState } from "./model";
 
 export interface RunSurfaceProps {
@@ -46,6 +47,7 @@ export interface RunViewModel {
     runId: string;
     status: Status;
     planTitle: string;
+    planId: string;
     attemptLabel: string;
   };
   timeline: TimelineMilestoneRunViewModel[];
@@ -108,6 +110,7 @@ export function buildRunViewModel(state: RunState): RunViewModel {
       runId: state.run.id,
       status: toRunStatus(state.run.status),
       planTitle: state.plan.title,
+      planId: state.plan.id,
       attemptLabel: `Attempt ${state.run.attempt}`
     },
     timeline,
@@ -151,9 +154,13 @@ export function RunSurface({ state }: RunSurfaceProps): JSX.Element {
             <h2 class="truncate text-[length:var(--text-base)] font-semibold">
               {viewModel.header.runId}
             </h2>
-            <p class="text-[length:var(--text-sm)] text-[color:var(--color-vscode-description)]">
+            <button
+              type="button"
+              class="block text-[length:var(--text-sm)] text-[color:var(--color-vscode-text-link)] hover:underline text-left"
+              onClick={() => openPlan(viewModel.header.planId)}
+            >
               {viewModel.header.planTitle}
-            </p>
+            </button>
           </div>
           <div class="flex items-center gap-2">
             <StatusBadge status={viewModel.header.status} variant="text" />

--- a/packages/webview/test/plan/plan-surface.test.ts
+++ b/packages/webview/test/plan/plan-surface.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it } from "vitest";
 import { buildPlanViewModel } from "../../src/plan/PlanSurface";
 import type { PlanState } from "../../src/plan/model";
 
+function extractFilename(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, "/");
+  const lastSlash = normalized.lastIndexOf("/");
+  return lastSlash === -1 ? filePath : normalized.slice(lastSlash + 1);
+}
+
 function makeState(overrides?: Partial<PlanState>): PlanState {
   const base: PlanState = {
     plan: {
@@ -109,6 +115,33 @@ describe("buildPlanViewModel", () => {
         message: "Acceptance criteria mismatch"
       }
     ]);
+  });
+
+  it("uses repository name when available in the repository view model", () => {
+    const state = makeState();
+    state.plan.repositories[0] = {
+      ...state.plan.repositories[0]!,
+      name: "my-app"
+    };
+
+    const vm = buildPlanViewModel(state);
+
+    expect(vm.repositories[0]!.name).toBe("my-app");
+    expect(vm.repositories[0]!.repositoryId).toBe("repo-main");
+  });
+
+  it("leaves repository name undefined when name is absent from the repository ref", () => {
+    const vm = buildPlanViewModel(makeState());
+
+    expect(vm.repositories[0]!.name).toBeUndefined();
+    expect(vm.repositories[0]!.repositoryId).toBe("repo-main");
+  });
+
+  it("normalizes access field to Writable/Read-only display labels", () => {
+    const vm = buildPlanViewModel(makeState());
+
+    expect(vm.repositories[0]!.accessLabel).toBe("Writable");
+    expect(vm.repositories[1]!.accessLabel).toBe("Read-only");
   });
 
   it("builds empty arrays and zero progress for empty state", () => {
@@ -228,5 +261,33 @@ describe("buildPlanViewModel", () => {
     );
 
     expect(vm.milestoneProgress).toEqual({ current: 2, total: 3 });
+  });
+});
+
+describe("extractFilename", () => {
+  it("extracts filename from Unix-style path", () => {
+    expect(extractFilename(".attractor/plans/oauth-login.dot")).toBe(
+      "oauth-login.dot"
+    );
+    expect(extractFilename("graph/plan.dot")).toBe("plan.dot");
+    expect(extractFilename("deep/nested/dir/file.txt")).toBe("file.txt");
+  });
+
+  it("extracts filename from Windows-style path", () => {
+    expect(extractFilename("C:\\plans\\flow.dot")).toBe("flow.dot");
+    expect(extractFilename("folder\\subfolder\\file.txt")).toBe("file.txt");
+  });
+
+  it("handles mixed path separators", () => {
+    expect(extractFilename("C:\\plans/flow.dot")).toBe("flow.dot");
+  });
+
+  it("returns input unchanged if no path separators", () => {
+    expect(extractFilename("simple.dot")).toBe("simple.dot");
+    expect(extractFilename("file.txt")).toBe("file.txt");
+  });
+
+  it("handles trailing slashes", () => {
+    expect(extractFilename("path/to/dir/")).toBe("");
   });
 });

--- a/packages/webview/test/repository/repository-surface.test.ts
+++ b/packages/webview/test/repository/repository-surface.test.ts
@@ -168,18 +168,21 @@ describe("RepositorySurface", () => {
     expect(vm.runs).toEqual([
       {
         id: "run-1",
+        planId: "plan-draft",
         status: "queued",
         attempt: 1,
         createdAt: "2026-01-20T00:00:00Z"
       },
       {
         id: "run-2",
+        planId: "plan-completed",
         status: "succeeded",
         attempt: 2,
         createdAt: "2026-01-21T00:00:00Z"
       },
       {
         id: "run-3",
+        planId: "plan-paused",
         status: "blocked",
         attempt: 1,
         createdAt: "2026-01-22T00:00:00Z"

--- a/packages/webview/test/run/run-surface.test.ts
+++ b/packages/webview/test/run/run-surface.test.ts
@@ -103,6 +103,7 @@ describe("RunSurface", () => {
       runId: "run-001",
       status: "blocked",
       planTitle: "Ship run inspector surface",
+      planId: "plan-001",
       attemptLabel: "Attempt 2"
     });
     expect(vm.timeline).toHaveLength(2);


### PR DESCRIPTION
## Summary

Addresses [GLA-66](/GLA/issues/GLA-66) by simplifying the graph source display.

## Changes

- Extract filename from full path in graph source display
- Change label from 'Graph Source:' to 'Graph:' for conciseness  
- Reduce visual clutter from debug-level metadata
- Add extractFilename utility function to handle Unix and Windows paths
- Add comprehensive test cases for filename extraction edge cases

## Testing

- All 12 plan-surface tests pass
- Typecheck and lint pass
- Tests cover Unix paths, Windows paths, mixed separators, and edge cases