### PR TITLE
feat: show elapsed duration on completed timeline milestones (#GLA-79)

### DIFF
--- a/packages/webview/src/lib/utils.ts
+++ b/packages/webview/src/lib/utils.ts
@@ -10,3 +10,26 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Format the duration between two ISO 8601 timestamps.
+ * Returns a human-readable string like "15m 30s" or "2h 5m".
+ * If end time is before start time, returns "0s".
+ */
+export function formatDuration(startIso: string, endIso: string): string {
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+  const diffMs = Math.max(0, end.getTime() - start.getTime());
+
+  const totalSeconds = Math.floor(diffMs / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const parts: string[] = [];
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+
+  return parts.join(" ");
+}

--- a/packages/webview/src/run/RunSurface.tsx
+++ b/packages/webview/src/run/RunSurface.tsx
@@ -11,7 +11,7 @@ import {
   StatusBadge,
   type Status
 } from "../components";
-import { cn } from "../lib/utils";
+import { cn, formatDuration } from "../lib/utils";
 import type { RunState } from "./model";
 
 export interface RunSurfaceProps {
@@ -208,7 +208,11 @@ export function RunSurface({ state }: RunSurfaceProps): JSX.Element {
                       </div>
                       {milestoneRun.endedAt && (
                         <div class="text-[length:var(--text-xs)] text-[color:var(--color-vscode-description)]">
-                          Ended: {milestoneRun.endedAt}
+                          Ended: {milestoneRun.endedAt} · Duration:{" "}
+                          {formatDuration(
+                            milestoneRun.startedAt,
+                            milestoneRun.endedAt
+                          )}
                         </div>
                       )}
                       {milestoneRun.errorMessage && (

--- a/packages/webview/test/lib/utils.test.ts
+++ b/packages/webview/test/lib/utils.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDuration } from "../../src/lib/utils";
+
+describe("formatDuration", () => {
+  it("formats durations with hours, minutes, and seconds", () => {
+    const start = "2026-04-03T10:00:00.000Z";
+    const end = "2026-04-03T12:05:30.000Z";
+    expect(formatDuration(start, end)).toBe("2h 5m 30s");
+  });
+
+  it("formats durations with minutes and seconds", () => {
+    const start = "2026-04-03T10:00:00.000Z";
+    const end = "2026-04-03T10:15:45.000Z";
+    expect(formatDuration(start, end)).toBe("15m 45s");
+  });
+
+  it("formats durations with only seconds", () => {
+    const start = "2026-04-03T10:00:00.000Z";
+    const end = "2026-04-03T10:00:30.000Z";
+    expect(formatDuration(start, end)).toBe("30s");
+  });
+
+  it("formats durations with only minutes", () => {
+    const start = "2026-04-03T10:00:00.000Z";
+    const end = "2026-04-03T10:30:00.000Z";
+    expect(formatDuration(start, end)).toBe("30m");
+  });
+
+  it("formats durations with only hours", () => {
+    const start = "2026-04-03T10:00:00.000Z";
+    const end = "2026-04-03T14:00:00.000Z";
+    expect(formatDuration(start, end)).toBe("4h");
+  });
+
+  it("returns 0s for zero duration", () => {
+    const start = "2026-04-03T10:00:00.000Z";
+    expect(formatDuration(start, start)).toBe("0s");
+  });
+
+  it("returns 0s when end is before start", () => {
+    const start = "2026-04-03T10:00:00.000Z";
+    const end = "2026-04-03T09:00:00.000Z";
+    expect(formatDuration(start, end)).toBe("0s");
+  });
+
+  it("ignores milliseconds in calculation", () => {
+    const start = "2026-04-03T10:00:00.000Z";
+    const end = "2026-04-03T10:00:00.500Z";
+    expect(formatDuration(start, end)).toBe("0s");
+  });
+
+  it("handles large durations", () => {
+    const start = "2026-04-03T00:00:00.000Z";
+    const end = "2026-04-05T05:30:45.000Z";
+    expect(formatDuration(start, end)).toBe("53h 30m 45s");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `formatDuration` utility function to calculate elapsed time between two ISO timestamps
- Format duration with hours, minutes, and seconds (e.g., '2h 5m 30s', '15m 45s', '30s')
- Display duration alongside ended timestamp on completed milestone runs in the timeline
- Comprehensive test coverage for edge cases (zero duration, partial hours, etc.)

## Files Changed

- `packages/webview/src/lib/utils.ts` — new formatDuration function
- `packages/webview/src/run/RunSurface.tsx` — import and display duration in JSX
- `packages/webview/test/lib/utils.test.ts` — 9 unit tests for duration formatting

## Verification

- ✅ TypeScript: no type errors
- ✅ Lint: all rules pass
- ✅ Tests: 9/9 duration tests pass (532/533 total suite pass, only VSIX env test fails as expected)